### PR TITLE
task(int-738): List spaces from all regions in spaces command

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -435,8 +435,9 @@ program
       if (!api.isAuthorized()) {
         await api.processLogin()
       }
+      const { region } = creds.get()
 
-      await tasks.listSpaces(api)
+      await tasks.listSpaces(api, region)
     } catch (e) {
       console.log(chalk.red('X') + ' An error ocurred to listing spaces: ' + e.message)
       process.exit(1)

--- a/src/tasks/list-spaces.js
+++ b/src/tasks/list-spaces.js
@@ -1,15 +1,12 @@
 const chalk = require('chalk')
-const creds = require('../utils/creds')
-
 /**
  * @method listSpaces
  * @param api - Pass the api instance as a parameter
  * @return {Promise}
  */
 
-const listSpaces = async (api) => {
-  const { region } = creds.get()
-  const isChinaEnv = region === 'cn'
+const listSpaces = async (api, currentRegion) => {
+  const isChinaEnv = currentRegion === 'cn'
   const regionOptions = {
     eu: 'Europe',
     us: 'United States'
@@ -23,7 +20,7 @@ const listSpaces = async (api) => {
   }
 
   if (isChinaEnv) {
-    const spaces = await api.getAllSpaces(region)
+    const spaces = await api.getAllSpacesByRegion(currentRegion)
       .then(res => res)
       .catch(err => Promise.reject(err))
 
@@ -31,15 +28,16 @@ const listSpaces = async (api) => {
       console.log(chalk.red('X') + ' No spaces were found for this user ')
       return []
     }
-    console.log(chalk.blue(' -') + ' Spaces From China')
+    console.log(chalk.blue(' -') + ' Spaces From China region:')
 
     spaces.map(space => {
       console.log(`    ${space.name} (id: ${space.id})`)
     })
+    return spaces
   } else {
     const spacesList = []
     for (const key in regionOptions) {
-      spacesList.push(await api.getAllSpaces(key)
+      spacesList.push(await api.getAllSpacesByRegion(key)
         .then((res) => {
           return {
             key,
@@ -54,11 +52,12 @@ const listSpaces = async (api) => {
     }
     spacesList.forEach(region => {
       console.log()
-      console.log(`${chalk.blue(' -')} Spaces From ${regionOptions[region.key]}:`)
+      console.log(`${chalk.blue(' -')} Spaces From ${regionOptions[region.key]} region:`)
       region.res.forEach((space) => {
         console.log(`    ${space.name} (id: ${space.id})`)
       })
     })
+    return spacesList
   }
 }
 

--- a/src/tasks/list-spaces.js
+++ b/src/tasks/list-spaces.js
@@ -1,4 +1,5 @@
 const chalk = require('chalk')
+const creds = require('../utils/creds')
 
 /**
  * @method listSpaces
@@ -7,29 +8,58 @@ const chalk = require('chalk')
  */
 
 const listSpaces = async (api) => {
+  const { region } = creds.get()
+  const isChinaEnv = region === 'cn'
+  const regionOptions = {
+    eu: 'Europe',
+    us: 'United States'
+  }
   console.log()
   console.log(chalk.green('✓') + ' Loading spaces...')
-  console.log()
 
   if (!api) {
     console.log(chalk.red('X') + 'Api instance is required to make the request')
     return []
   }
 
-  const spaces = await api.getAllSpaces()
-    .then(res => res)
-    .catch(err => Promise.reject(err))
+  if (isChinaEnv) {
+    const spaces = await api.getAllSpaces(region)
+      .then(res => res)
+      .catch(err => Promise.reject(err))
 
-  if (!spaces) {
-    console.log(chalk.red('X') + ' No spaces were found for this user ')
-    return []
+    if (!spaces) {
+      console.log(chalk.red('X') + ' No spaces were found for this user ')
+      return []
+    }
+    console.log(chalk.blue(' -') + ' Spaces From China')
+
+    spaces.map(space => {
+      console.log(`    ${space.name} (id: ${space.id})`)
+    })
+  } else {
+    const spacesList = []
+    for (const key in regionOptions) {
+      spacesList.push(await api.getAllSpaces(key)
+        .then((res) => {
+          return {
+            key,
+            res
+          }
+        })
+        .catch(err => Promise.reject(err)))
+    }
+    if (!spacesList) {
+      console.log(chalk.red('X') + ' No spaces were found for this user ')
+      return []
+    }
+    spacesList.forEach(region => {
+      console.log()
+      console.log(`${chalk.blue(' -')} Spaces From ${regionOptions[region.key]}:`)
+      region.res.forEach((space) => {
+        console.log(`    ${space.name} (id: ${space.id})`)
+      })
+    })
   }
-
-  spaces.map(space => {
-    console.log(`${space.name} (id: ${space.id})`)
-  })
-
-  return spaces
 }
 
 module.exports = listSpaces

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -240,7 +240,7 @@ module.exports = {
     return client[method](_path, props)
   },
 
-  async getAllSpaces (region) {
+  async getAllSpacesByRegion (region) {
     const customClient = new Storyblok({
       accessToken: this.accessToken,
       oauthToken: this.oauthToken,

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -240,8 +240,13 @@ module.exports = {
     return client[method](_path, props)
   },
 
-  async getAllSpaces () {
-    return await this.getClient()
+  async getAllSpaces (region) {
+    const customClient = new Storyblok({
+      accessToken: this.accessToken,
+      oauthToken: this.oauthToken,
+      region
+    }, this.apiSwitcher(region))
+    return await customClient
       .get('spaces/', {})
       .then(res => res.data.spaces || [])
       .catch(err => Promise.reject(err))

--- a/tests/units/list-spaces.spec.js
+++ b/tests/units/list-spaces.spec.js
@@ -1,6 +1,12 @@
 const { listSpaces } = require('../../src/tasks/')
 const { FAKE_SPACES } = require('../constants')
 
+const REGION_FLAGS = {
+  UNITED_STATES: 'us',
+  EUROPE: 'eu',
+  CHINA: 'cn'
+}
+
 describe('Test spaces method', () => {
   it('Testing list-spaces funtion without api instance', async () => {
     try {
@@ -10,13 +16,34 @@ describe('Test spaces method', () => {
       console.error(e)
     }
   })
-  it('Testing list-spaces funtion with api instance', async () => {
+
+  it('Testing list-spaces function for China region', async () => {
     const FAKE_API = {
-      getAllSpaces: jest.fn(() => Promise.resolve(FAKE_SPACES()))
+      getAllSpacesByRegion: jest.fn(() => Promise.resolve(FAKE_SPACES()))
     }
     expect(
-      await listSpaces(FAKE_API)
+      await listSpaces(FAKE_API, REGION_FLAGS.CHINA)
     ).toEqual(FAKE_SPACES())
-    expect(FAKE_API.getAllSpaces).toHaveBeenCalled()
+    expect(FAKE_API.getAllSpacesByRegion).toHaveBeenCalled()
+  })
+
+  it('Testing list-spaces funtion for Europe and United States regions', async () => {
+    const FAKE_API = {
+      getAllSpacesByRegion: jest.fn(() => Promise.resolve(FAKE_SPACES()))
+    }
+    const response = [
+      {
+        key: REGION_FLAGS.EUROPE,
+        res: [...FAKE_SPACES()]
+      },
+      {
+        key: REGION_FLAGS.UNITED_STATES,
+        res: [...FAKE_SPACES()]
+      }
+    ]
+
+    expect(
+      await listSpaces(FAKE_API, REGION_FLAGS.EUROPE)
+    ).toEqual(response)
   })
 })


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [INT-738](https://storyblok.atlassian.net/browse/INT-738)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:-->

- [x] Feature

## How to test this PR

Please take a look on the video bellow, you can see on the video the new features of the command

https://user-images.githubusercontent.com/40925579/209394093-b8e3d871-81c0-4a07-81c2-2346aad944af.mov

## What is the new behavior?

- Now the command `spaces` list all spaces when you use the **CN** region, and if you are using the **US** or **EU** the command shows all spaces from both regions

## Other information

It's related to this comment https://github.com/storyblok/storyblok-cli/issues/12