### PR TITLE
fix: changes ascii art to correspond to logo (lower-case s)

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -16,7 +16,7 @@ const { getQuestions, lastStep, api, creds } = require('./utils')
 const { SYNC_TYPES, COMMANDS } = require('./constants')
 
 clear()
-console.log(chalk.cyan(figlet.textSync('Storyblok')))
+console.log(chalk.cyan(figlet.textSync('storyblok')))
 console.log()
 console.log()
 console.log('Hi, welcome to the Storyblok CLI')


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
Previously the cli painted an ascii art with an upper-case, which does not correspond to the logo.

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

<!-- Please provide the steps on how to test this PR. -->
Run cli.js.

## What is the new behavior?

- The ascii art is now corresponding to logo with a lower-case "s" instead of a upper-case.

![image](https://user-images.githubusercontent.com/5083273/211283091-eb43d296-e6b1-4b1f-9c0e-42b9a9fd8292.png)

Old behavior:
![image](https://user-images.githubusercontent.com/5083273/211283840-40543ae8-9de8-4dd5-89d9-9268649429c5.png)

## Other information

Original issue raised: #13 