### PR TITLE
Sync Enhancement. Starts-With and Filter Query

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,9 @@ $ storyblok sync --type <COMMAND> --source <SPACE_ID> --target <SPACE_ID>
 * `source`: the source space to use to sync
 * `target`: the target space to use to sync
 * `starts-with`: sync only stories that starts with the given string
+* `filter`: sync stories based on the given filter. Required Options: Required options: `--keys`, `--operations`, `--values`
+* `keys`: Multiple keys should be inside quotes and separated by whitespace. Example: `--keys "key1 key2"`, `--keys key1`
+* `operations`: Operations to be used for filtering. Can be: `is`, `in`, `not_in`, `like`, `not_like`, `any_in_array`, `all_in_array`, `gt_date`, `lt_date`, `gt_int`, `lt_int`, `gt_float`, `lt_float`. Multiple operations should be inside quotes and separated by whitespace.
 
 #### Examples
 
@@ -219,6 +222,12 @@ $ storyblok sync --type components,stories --source 00001 --target 00002
 
 # Sync only stories that starts with `myStartsWithString` from `00001` space to `00002` space
 $ storyblok sync --type stories --source 00001 --target 00002 --starts-with myStartsWithString
+
+# Sync only stories with a category field like `reference` from `00001` space to `00002` space
+$ storyblok sync --type stories --source 00001 --target 00002 --filter --keys category --operations like --values reference
+
+# Sync only stories with a category field like `reference` and a name field not like `demo` from `00001` space to `00002` space
+$ storyblok sync --type stories --source 00001 --target 00002 --filter --keys "category name" --operations "like not_like" --values "reference demo"
 ```
 
 ### quickstart

--- a/README.md
+++ b/README.md
@@ -227,8 +227,8 @@ $ storyblok sync --type <COMMAND> --source <SPACE_ID> --target <SPACE_ID>
 * `target`: the target space to use to sync
 * `starts-with`: sync only stories that starts with the given string
 * `filter`: sync stories based on the given filter. Required Options: Required options: `--keys`, `--operations`, `--values`
-* `keys`: Multiple keys should be inside quotes and separated by whitespace. Example: `--keys "key1 key2"`, `--keys key1`
-* `operations`: Operations to be used for filtering. Can be: `is`, `in`, `not_in`, `like`, `not_like`, `any_in_array`, `all_in_array`, `gt_date`, `lt_date`, `gt_int`, `lt_int`, `gt_float`, `lt_float`. Multiple operations should be inside quotes and separated by whitespace.
+* `keys`: Multiple keys should be separated by comma. Example: `--keys key1,key2`, `--keys key1`
+* `operations`: Operations to be used for filtering. Can be: `is`, `in`, `not_in`, `like`, `not_like`, `any_in_array`, `all_in_array`, `gt_date`, `lt_date`, `gt_int`, `lt_int`, `gt_float`, `lt_float`. Multiple operations should be separated by comma.
 
 #### Examples
 
@@ -246,7 +246,7 @@ $ storyblok sync --type stories --source 00001 --target 00002 --starts-with mySt
 $ storyblok sync --type stories --source 00001 --target 00002 --filter --keys category --operations like --values reference
 
 # Sync only stories with a category field like `reference` and a name field not like `demo` from `00001` space to `00002` space
-$ storyblok sync --type stories --source 00001 --target 00002 --filter --keys "category name" --operations "like not_like" --values "reference demo"
+$ storyblok sync --type stories --source 00001 --target 00002 --filter --keys category,name --operations like,not_like --values reference,demo
 ```
 
 ### quickstart

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ $ storyblok sync --type <COMMAND> --source <SPACE_ID> --target <SPACE_ID>
 * `type`: describe the command type to execute. Can be: `folders`, `components`, `stories`, `datasources` or `roles`. It's possible pass multiple types separated by comma (`,`).
 * `source`: the source space to use to sync
 * `target`: the target space to use to sync
+* `starts-with`: sync only stories that starts with the given string
 
 #### Examples
 
@@ -215,6 +216,9 @@ $ storyblok sync --type components --source 00001 --target 00002
 
 # Sync components and stories from `00001` space to `00002` space
 $ storyblok sync --type components,stories --source 00001 --target 00002
+
+# Sync only stories that starts with `myStartsWithString` from `00001` space to `00002` space
+$ storyblok sync --type stories --source 00001 --target 00002 --starts-with myStartsWithString
 ```
 
 ### quickstart

--- a/src/cli.js
+++ b/src/cli.js
@@ -12,7 +12,7 @@ const updateNotifier = require('update-notifier')
 const pkg = require('../package.json')
 
 const tasks = require('./tasks')
-const { getQuestions, lastStep, api, creds } = require('./utils')
+const { getQuestions, lastStep, api, creds, buildFilterQuery } = require('./utils')
 const { SYNC_TYPES, COMMANDS } = require('./constants')
 
 clear()
@@ -292,27 +292,7 @@ program
         }
       })
 
-      let filterQuery
-      if (filter) {
-        const operators = ['is', 'in', 'not_in', 'like', 'not_like', 'any_in_array', 'all_in_array', 'gt_date', 'lt_date', 'gt_int', 'lt_int', 'gt_float', 'lt_float']
-        if (!keys || !operations || !values) {
-          throw new Error('Filter options are required: --keys; --operations; --values')
-        }
-        const _keys = keys.split(' ')
-        const _operations = operations.split(' ')
-        const _values = values.split(' ')
-        if (_keys.length !== _operations.length || _keys.length !== _values.length) {
-          throw new Error('The number of keys, operations and values must be the same')
-        }
-        const invalidOperators = _operations.filter((o) => !operators.includes(o))
-        if (invalidOperators.length) {
-          throw new Error('Invalid operator(s) applied for filter: ' + invalidOperators.join(' '))
-        }
-        filterQuery = {}
-        _keys.forEach((key, index) => {
-          filterQuery[key] = { [_operations[index]]: _values[index] }
-        })
-      }
+      const filterQuery = filter ? buildFilterQuery(keys, operations, values) : undefined
 
       const token = creds.get().token || null
       await tasks.sync(_types, {

--- a/src/cli.js
+++ b/src/cli.js
@@ -270,9 +270,9 @@ program
   .requiredOption('--target <SPACE_ID>', 'Target space id')
   .option('--starts-with <STARTS_WITH>', 'Sync only stories that starts with the given string')
   .option('--filter', 'Enable filter options to sync only stories that match the given filter. Required options: --keys; --operations; --values')
-  .option('--keys <KEYS>', 'Field names in your story object which should be used for filtering. Multiple keys should be inside quotes and separated by whitespace.')
-  .option('--operations <OPERATIONS>', 'Operations to be used for filtering. Can be: is, in, not_in, like, not_like, any_in_array, all_in_array, gt_date, lt_date, gt_int, lt_int, gt_float, lt_float. Multiple operations should be inside quotes and separated by whitespace.')
-  .option('--values <VALUES>', 'Values to be used for filtering. Any string or number. If you want to use multiple values, separate them with a comma. Multiple values should be inside quotes and separated by whitespace.')
+  .option('--keys <KEYS>', 'Field names in your story object which should be used for filtering. Multiple keys should separated by comma.')
+  .option('--operations <OPERATIONS>', 'Operations to be used for filtering. Can be: is, in, not_in, like, not_like, any_in_array, all_in_array, gt_date, lt_date, gt_int, lt_int, gt_float, lt_float. Multiple operations should be separated by comma.')
+  .option('--values <VALUES>', 'Values to be used for filtering. Any string or number. If you want to use multiple values, separate them with a comma. Multiple values should be separated by comma.')
   .action(async (options) => {
     console.log(`${chalk.blue('-')} Sync data between spaces\n`)
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -261,6 +261,7 @@ program
   .requiredOption('--type <TYPE>', 'Define what will be sync. Can be components, folders, stories, datasources or roles')
   .requiredOption('--source <SPACE_ID>', 'Source space id')
   .requiredOption('--target <SPACE_ID>', 'Target space id')
+  .option('--starts-with <STARTS_WITH>', 'Sync only stories that starts with the given string')
   .action(async (options) => {
     console.log(`${chalk.blue('-')} Sync data between spaces\n`)
 
@@ -272,7 +273,8 @@ program
       const {
         type,
         source,
-        target
+        target,
+        startsWith
       } = options
 
       const _types = type.split(',') || []
@@ -288,7 +290,8 @@ program
         api,
         token,
         source,
-        target
+        target,
+        startsWith
       })
 
       console.log('\n' + chalk.green('✓') + ' Sync data between spaces successfully completed')

--- a/src/tasks/sync.js
+++ b/src/tasks/sync.js
@@ -16,6 +16,7 @@ const SyncSpaces = {
     this.targetSpaceId = options.target
     this.oauthToken = options.token
     this.startsWith = options.startsWith
+    this.filterQuery = options.filterQuery
     this.client = api.getClient()
   },
 
@@ -59,7 +60,8 @@ const SyncSpaces = {
 
     const all = await this.client.getAll(`spaces/${this.sourceSpaceId}/stories`, {
       story_only: 1,
-      ...(this.startsWith ? { starts_with: this.startsWith } : {})
+      ...(this.startsWith ? { starts_with: this.startsWith } : {}),
+      ...(this.filterQuery ? { filter_query: this.filterQuery } : {})
     })
 
     for (let i = 0; i < all.length; i++) {

--- a/src/tasks/sync.js
+++ b/src/tasks/sync.js
@@ -3,6 +3,7 @@ const chalk = require('chalk')
 const SyncComponents = require('./sync-commands/components')
 const SyncDatasources = require('./sync-commands/datasources')
 const { capitalize } = require('../utils')
+const { startsWith } = require('lodash/string')
 
 const SyncSpaces = {
   targetComponents: [],
@@ -14,6 +15,7 @@ const SyncSpaces = {
     this.sourceSpaceId = options.source
     this.targetSpaceId = options.target
     this.oauthToken = options.token
+    this.startsWith = options.startsWith
     this.client = api.getClient()
   },
 
@@ -56,7 +58,8 @@ const SyncSpaces = {
     }
 
     const all = await this.client.getAll(`spaces/${this.sourceSpaceId}/stories`, {
-      story_only: 1
+      story_only: 1,
+      ...(this.startsWith ? { starts_with: this.startsWith } : {})
     })
 
     for (let i = 0; i < all.length; i++) {

--- a/src/utils/build-filter-query.js
+++ b/src/utils/build-filter-query.js
@@ -3,9 +3,9 @@ const buildFilterQuery = (keys, operations, values) => {
   if (!keys || !operations || !values) {
     throw new Error('Filter options are required: --keys; --operations; --values')
   }
-  const _keys = keys.split(' ')
-  const _operations = operations.split(' ')
-  const _values = values.split(' ')
+  const _keys = keys.split(',')
+  const _operations = operations.split(',')
+  const _values = values.split(',')
   if (_keys.length !== _operations.length || _keys.length !== _values.length) {
     throw new Error('The number of keys, operations and values must be the same')
   }

--- a/src/utils/build-filter-query.js
+++ b/src/utils/build-filter-query.js
@@ -1,0 +1,23 @@
+const buildFilterQuery = (keys, operations, values) => {
+  const operators = ['is', 'in', 'not_in', 'like', 'not_like', 'any_in_array', 'all_in_array', 'gt_date', 'lt_date', 'gt_int', 'lt_int', 'gt_float', 'lt_float']
+  if (!keys || !operations || !values) {
+    throw new Error('Filter options are required: --keys; --operations; --values')
+  }
+  const _keys = keys.split(' ')
+  const _operations = operations.split(' ')
+  const _values = values.split(' ')
+  if (_keys.length !== _operations.length || _keys.length !== _values.length) {
+    throw new Error('The number of keys, operations and values must be the same')
+  }
+  const invalidOperators = _operations.filter((o) => !operators.includes(o))
+  if (invalidOperators.length) {
+    throw new Error('Invalid operator(s) applied for filter: ' + invalidOperators.join(' '))
+  }
+  const filterQuery = {}
+  _keys.forEach((key, index) => {
+    filterQuery[key] = { [_operations[index]]: _values[index] }
+  })
+  return filterQuery
+}
+
+module.exports = buildFilterQuery

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -5,5 +5,6 @@ module.exports = {
   creds: require('./creds'),
   capitalize: require('./capitalize'),
   findByProperty: require('./find-by-property'),
-  parseError: require('./parse-error')
+  parseError: require('./parse-error'),
+  buildFilterQuery: require('./build-filter-query')
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

```bash
# Sync only stories that starts with `myStartsWithString` from `00001` space to `00002` space
$ storyblok sync --type stories --source 00001 --target 00002 --starts-with myStartsWithString

# Sync only stories with a category field like `reference` from `00001` space to `00002` space
$ storyblok sync --type stories --source 00001 --target 00002 --filter --keys category --operations like --values reference

# Sync only stories with a category field like `reference` and a name field not like `demo` from `00001` space to `00002` space
$ storyblok sync --type stories --source 00001 --target 00002 --filter --keys "category name" --operations "like not_like" --values "reference demo"
```

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

Added starts_with parameter and a filter query. Description:

* `starts-with`: sync only stories that starts with the given string
* `filter`: sync stories based on the given filter. Required Options: Required options: `--keys`, `--operations`, `--values`
* `keys`: Multiple keys should be inside quotes and separated by whitespace. Example: `--keys "key1 key2"`, `--keys key1`
* `operations`: Operations to be used for filtering. Can be: `is`, `in`, `not_in`, `like`, `not_like`, `any_in_array`, `all_in_array`, `gt_date`, `lt_date`, `gt_int`, `lt_int`, `gt_float`, `lt_float`. Multiple operations should be inside quotes and separated by whitespace.

