### PR TITLE
feat: added option to specify filname to pull-components command

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ $ storyblok pull-components --space <SPACE_ID> # Will save files like components
 ```
 
 ```sh
-$ storyblok pull-components --space <SPACE_ID> --separate-files # Will save files like feature-1234.json grid-1234.json
+$ storyblok pull-components --space <SPACE_ID> --separate-files  --file-name production # Will save files like feature-production.json grid-production.json
 ```
 
 #### Options
@@ -103,6 +103,7 @@ $ storyblok pull-components --space <SPACE_ID> --separate-files # Will save file
 * `space`: your space id
 * `separate-files`: boolean flag to save components and presets in single files instead a file with all
 * `path`: the path to save your components and preset files
+* `file-name`(optional): a custom filename used to generate the component and present files, default is the space id
 
 ### push-components
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A simple CLI to start Storyblok from your command line.",
   "repository": {
     "type": "git",
-    "url": "https://github.com/storyblok/storyblok-cli.git"
+    "url": "https://github.com/towa-digital/storyblok-cli.git"
   },
   "keywords": [
     "storyblok",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "storyblok",
-  "version": "3.15.0",
+  "name": "towa-storyblok",
+  "version": "3.16.0",
   "description": "A simple CLI to start Storyblok from your command line.",
   "repository": {
     "type": "git",

--- a/src/cli.js
+++ b/src/cli.js
@@ -121,6 +121,7 @@ program
   .command(COMMANDS.PULL_COMPONENTS)
   .option('--sf, --separate-files [value]', 'Argument to create a single file for each component')
   .option('-p, --path <path>', 'Path to save the component files')
+  .option('-f, --file-name <fileName>', 'custom name to be used in file(s) name instead of space id')
   .description("Download your space's components schema as json")
   .action(async (options) => {
     console.log(`${chalk.blue('-')} Executing pull-components task`)
@@ -131,13 +132,15 @@ program
       process.exit(0)
     }
 
+    const fileName = options.fileName ? options.fileName : space
+
     try {
       if (!api.isAuthorized()) {
         await api.processLogin()
       }
 
       api.setSpaceId(space)
-      await tasks.pullComponents(api, { space, separateFiles, path })
+      await tasks.pullComponents(api, { fileName, separateFiles, path })
     } catch (e) {
       errorHandler(e, COMMANDS.PULL_COMPONENTS)
     }

--- a/src/tasks/pull-components.js
+++ b/src/tasks/pull-components.js
@@ -20,11 +20,11 @@ const getNameFromComponentGroups = (groups, uuid) => {
 /**
  * @method pullComponents
  * @param  {Object} api
- * @param  {Object} options { space: Number, separateFiles: Boolean, path: String }
+ * @param  {Object} options { fileName: string, separateFiles: Boolean, path: String }
  * @return {Promise<Object>}
  */
 const pullComponents = async (api, options) => {
-  const { space, separateFiles, path } = options
+  const { fileName, separateFiles, path } = options
 
   try {
     const componentGroups = await api.getComponentGroups()
@@ -43,7 +43,7 @@ const pullComponents = async (api, options) => {
 
     if (separateFiles) {
       for (const comp in components) {
-        const compFileName = `${components[comp].name}-${space}.json`
+        const compFileName = `${components[comp].name}-${fileName}.json`
         const data = JSON.stringify(components[comp], null, 2)
         saveFileFactory(compFileName, data, path)
       }
@@ -52,7 +52,7 @@ const pullComponents = async (api, options) => {
       if (presets.length === 0) return
 
       for (const preset in presets) {
-        const presetFileName = `${presets[preset].name}-${space}.json`
+        const presetFileName = `${presets[preset].name}-${fileName}.json`
         const data = JSON.stringify(presets[preset], null, 2)
         saveFileFactory(presetFileName, data, path)
       }
@@ -60,7 +60,7 @@ const pullComponents = async (api, options) => {
       return
     }
 
-    const file = `components.${space}.json`
+    const file = `components.${fileName}.json`
     const data = JSON.stringify({ components }, null, 2)
 
     console.log(`${chalk.green('✓')} We've saved your components in the file: ${file}`)
@@ -69,7 +69,7 @@ const pullComponents = async (api, options) => {
 
     if (presets.length === 0) return
 
-    const presetsFile = `presets.${space}.json`
+    const presetsFile = `presets.${fileName}.json`
     const presetsData = JSON.stringify({ presets }, null, 2)
 
     console.log(`${chalk.green('✓')} We've saved your presets in the file: ${presetsFile}`)

--- a/tests/units/pull-components.spec.js
+++ b/tests/units/pull-components.spec.js
@@ -40,7 +40,7 @@ describe('testing pullComponents', () => {
     }
 
     const options = {
-      space: SPACE
+      compFileName: SPACE
     }
 
     const expectFileName = `components.${SPACE}.json`


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: -

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

<!-- Please provide the steps on how to test this PR. -->

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- adds `-f` flag to specify the file identifier for the pull-component command
- this gives the user the option to have files saved not with space id as suffix but with a custom id i.e.: `components.production.json`
- This is helpful for keeping track of differen versions of components, or for merging components from different spaces

## Other information

I created a similar PR last year for the old repo, I don't know what happened with it.