### PR TITLE
feat: added multi file support for delete components command

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,25 @@ storyblok delete-components <SOURCE> --space <SPACE_ID>
 ```
 
 #### Parameters
-* `source`: can be a URL or path to JSON file.
+* `source`: can be a URL or path to JSON file, the path to a json file could be to a single or multiple files separated by comma, like `./pages-1234.json,../User/components/grid-1234.json`
+
+Using an **URL**
+
+```sh
+$ storyblok push-components https://raw.githubusercontent.com/storyblok/nuxtdoc/master/seed.components.json --space 67819
+```
+
+Using a **path** to a single file
+
+```sh
+$ storyblok push-components ./components.json --space 67819
+```
+
+Using a **path** to a multiple files
+
+```sh
+$ storyblok push-components ./page.json,../grid.json,./feature.json --space 67819
+```
 
 #### Options
 * `space_id`: the space where the command should be executed.

--- a/src/tasks/delete-components.js
+++ b/src/tasks/delete-components.js
@@ -102,7 +102,7 @@ const deleteComponentsReversed = async (api, components, spaceComponents, dryrun
 
 const deleteComponentAndSkip = async (api, c, dryrun) => {
   try {
-    return await deleteComponent(api, { comp: c.id, dryrun: dryrun })
+    return await deleteComponent(api, { comp: c.name, dryrun: dryrun })
   } catch (e) {
     console.log(chalk.red('-') + ' Error deleting component ' + chalk.blue(c.name) + '! Skipped...')
   }

--- a/src/tasks/delete-components.js
+++ b/src/tasks/delete-components.js
@@ -92,12 +92,10 @@ const deleteAllComponents = async (api, components, dryrun) => {
  * @returns {Promise<void>}
  */
 const deleteComponentsReversed = async (api, components, spaceComponents, dryrun) => {
-  const unifiedComps = components.concat([...spaceComponents])
-  const toDelete = unifiedComps
-    .filter((value, index, self) =>
-      self.findIndex((o, i) => o.id === value.id && i !== index) < 0)
+  const toDeleteSpaceComponents = spaceComponents
+    .filter(spaceComponent => components.findIndex(o => o.name === spaceComponent.name) < 0)
   console.log(chalk.blue('-') + ' Deleting all components which do not appear in the given source.')
-  for (const c of toDelete) {
+  for (const c of toDeleteSpaceComponents) {
     await deleteComponentAndSkip(api, c, dryrun)
   }
 }

--- a/src/tasks/delete-components.js
+++ b/src/tasks/delete-components.js
@@ -7,24 +7,44 @@ const isUrl = source => source.indexOf('http') === 0
 
 /**
  * Get the data from a local or remote JSON file
- * @param {string} source the local path or remote url of the file
+ * @param {string} path the local path or remote url of the file
  * @returns {Promise<Object>} return the data from the source or an error
  */
-const getDataFromSource = async (source) => {
-  if (!source) {
+const getDataFromPath = async (path) => {
+  if (!path) {
     return {}
   }
+  const sources = path.split(',')
+  const isList = sources.length > 1
 
   try {
-    if (isUrl(source)) {
-      return (await axios.get(source)).data
+    if (isUrl(path)) {
+      return (await axios.get(path)).data
     } else {
-      return JSON.parse(fs.readFileSync(source, 'utf8'))
+      if (!isList) return JSON.parse(fs.readFileSync(sources[0], 'utf8'))
+
+      const data = []
+      sources.forEach((source) => {
+        data.push(JSON.parse(fs.readFileSync(source, 'utf8')))
+      })
+      return data
     }
   } catch (err) {
-    console.error(`${chalk.red('X')} Can not load json file from ${source}`)
+    console.error(`${chalk.red('X')} Can not load json file from ${path}`)
     return Promise.reject(err)
   }
+}
+
+/**
+ * Creat an array based in the content parameter and the key provided
+ * @param {object} content the data to create a list
+ * @param {string} key key to serch in the content
+ * @returns {Array} return the data from the source or an error
+ */
+const createContentList = (content, key) => {
+  if (content[key]) return content[key]
+  else if (Array.isArray(content)) return [...content]
+  else return [content]
 }
 
 /**
@@ -37,7 +57,8 @@ const getDataFromSource = async (source) => {
  */
 const deleteComponents = async (api, { source, reversed = false, dryRun = false }) => {
   try {
-    const sourceComponents = (await getDataFromSource(source)).components || []
+    const rawComponents = (await getDataFromPath(source)) || []
+    const sourceComponents = createContentList(rawComponents, 'components')
     if (!reversed) {
       return deleteAllComponents(api, sourceComponents, dryRun)
     }


### PR DESCRIPTION
`Note: I have recreated this PR to clean up the commit history`

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: -

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

<!-- Please provide the steps on how to test this PR. -->

* Run the command with a single file:

```bash
node src/cli.js delete-components components/blog-post-123456.json  --space 123456
```

* Run the command with multiple files:

```bash
node src/cli.js delete-components components/blog-post-123456.json,components/hero-text-123456.json  --space 123456
```

* Run with all possible options

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

* similar to the `push-components` command this pr adds the possibility to use multiple files (like created by --seperate-files flag for `pull-components`) for the `delete-components` command
* Since component ids change rather frequently when deleting, pulling & pushing components I suggest to use the component name instead to create a more reliable experience for the user when using the delete command

## Other information
