### PR TITLE
Fix datasource dimensions sync bug

### DIFF
--- a/src/tasks/sync-commands/datasources.js
+++ b/src/tasks/sync-commands/datasources.js
@@ -46,7 +46,7 @@ class SyncDatasources {
       const entriesFirstPage = await this.client.get(`spaces/${spaceId}/datasource_entries/?datasource_id=${datasourceId}${dimensionQuery}`)
       const entriesRequets = []
       for (let i = 2; i <= Math.ceil(entriesFirstPage.total / 25); i++) {
-        entriesRequets.push(this.client.get(`spaces/${spaceId}/datasource_entries/?datasource_id=${datasourceId}`, { page: i }))
+        entriesRequets.push(this.client.get(`spaces/${spaceId}/datasource_entries/?datasource_id=${datasourceId}${dimensionQuery}`, { page: i }))
       }
       return entriesFirstPage.data.datasource_entries.concat(...(await Promise.all(entriesRequets)).map(r => r.data.datasource_entries))
     } catch (err) {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [INT-](url)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:-->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

To test the PR (pull request) that addresses this issue, you can perform a simple sync command with the type set as "datasources." Here's an example command:
`storyblok sync --type datasources --source <SourceSpaceId> --target <TargetSpaceId>`

## What is the new behavior?

The new behaviour would be that all dimensions will be successfully synced from the source space to the target space, instead of just the first 25 dimensions.

## Other information

While running the datasource sync command `storyblok sync --type datasources --source <SourceSpaceId> --target <TargetSpaceId>`, I observed that only the initial 25 dimensions are synchronized to the destination space.