### PR TITLE
Delete datasource command

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,24 @@ For view the CLI version
 $ storyblok -V # or --version
 ```
 
+### delete-datasources
+
+The delete-datasources command enables you to remove all datasources within the designated space. By utilizing the `--by-slug` option, you can filter the datasources based on their slugs, selectively deleting specific datasources. Similarly, the `--by-name` option functions in the same way, allowing you to filter and delete datasources based on their names.
+
+```sh
+$ storyblok delete-datasources --space-id <SPACE_ID> # Will delete all datasources
+```
+
+```sh
+$ storyblok delete-datasources --space-id <SPACE_ID> --by-slug global-translations   # Will only delete datasources where the slug starts with global-translations
+```
+
+#### Options
+
+* `space-id`: your space id
+* `by-slug`: Filter Datasources by slug
+* `by-name`: Filter Datasources by name
+
 ## Content migrations
 
 Content migrations are a convenient way to change fields of your content.

--- a/src/cli.js
+++ b/src/cli.js
@@ -505,6 +505,30 @@ program
     }
   })
 
+  // pull-components
+program
+.command(COMMANDS.DELETE_DATASOURCES)
+.requiredOption('--space-id <SPACE_ID>', 'Space id')
+.option('--by-slug <SLUG>', 'Delete datasources by slug')
+.option('--by-name <name>', 'Delete datasources by name')
+.action(async (options) => {
+  console.log(`${chalk.blue('-')} Executing ${COMMANDS.DELETE_DATASOURCES} task`)
+
+  const { spaceId, bySlug, byName } = options
+
+  try {
+    if (!api.isAuthorized()) {
+      await api.processLogin()
+    }
+
+    api.setSpaceId(spaceId)
+
+    await tasks.deleteDatasources(api, { byName, bySlug })
+  } catch (e) {
+    errorHandler(e, COMMANDS.PULL_COMPONENTS)
+  }
+})
+
 program.parse(process.argv)
 
 if (program.rawArgs.length <= 2) {

--- a/src/cli.js
+++ b/src/cli.js
@@ -505,7 +505,7 @@ program
     }
   })
 
-  // pull-components
+  // delete-components
 program
 .command(COMMANDS.DELETE_DATASOURCES)
 .requiredOption('--space-id <SPACE_ID>', 'Space id')

--- a/src/cli.js
+++ b/src/cli.js
@@ -505,7 +505,7 @@ program
     }
   })
 
-  // delete-components
+  // delete-datasources
 program
 .command(COMMANDS.DELETE_DATASOURCES)
 .requiredOption('--space-id <SPACE_ID>', 'Space id')

--- a/src/cli.js
+++ b/src/cli.js
@@ -525,7 +525,7 @@ program
 
     await tasks.deleteDatasources(api, { byName, bySlug })
   } catch (e) {
-    errorHandler(e, COMMANDS.PULL_COMPONENTS)
+    errorHandler(e, COMMANDS.DELETE_DATASOURCES)
   }
 })
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -25,7 +25,8 @@ const COMMANDS = {
   SCAFFOLD: 'scaffold',
   SELECT: 'select',
   SPACES: 'spaces',
-  SYNC: 'sync'
+  SYNC: 'sync',
+  DELETE_DATASOURCES: 'delete-datasources'
 }
 
 module.exports = {

--- a/src/tasks/delete-datasources.js
+++ b/src/tasks/delete-datasources.js
@@ -34,7 +34,7 @@ const deleteDatasources = async (api, options) => {
     }
 
   } catch (e) {
-    console.error(`${chalk.red('X')} An error ocurred in pull-components task when load components data`)
+    console.error(`${chalk.red('X')} An error ocurred in delete-components task when deleting a datasource`)
     return Promise.reject(new Error(e))
   }
 }

--- a/src/tasks/delete-datasources.js
+++ b/src/tasks/delete-datasources.js
@@ -6,7 +6,7 @@ const chalk = require('chalk')
  * @param  {Object} options { fileName: string, separateFiles: Boolean, path: String }
  * @return {Promise<Object>}
  */
-const pullComponents = async (api, options) => {
+const deleteDatasources = async (api, options) => {
   const { byName, bySlug } = options
 
   try {

--- a/src/tasks/delete-datasources.js
+++ b/src/tasks/delete-datasources.js
@@ -39,4 +39,4 @@ const deleteDatasources = async (api, options) => {
   }
 }
 
-module.exports = pullComponents
+module.exports = deleteDatasources

--- a/src/tasks/delete-datasources.js
+++ b/src/tasks/delete-datasources.js
@@ -1,0 +1,42 @@
+const chalk = require('chalk')
+
+/**
+ * @method deleteDatasources
+ * @param  {Object} api
+ * @param  {Object} options { fileName: string, separateFiles: Boolean, path: String }
+ * @return {Promise<Object>}
+ */
+const pullComponents = async (api, options) => {
+  const { byName, bySlug } = options
+
+  try {
+    let datasources = await api.getDatasources()
+
+    if (bySlug) {
+      datasources = datasources.filter(datasource => datasource.slug.toLowerCase().startsWith(bySlug.toLowerCase()));
+      const filteredSlugs = datasources.map(obj => obj.slug);
+      const formattedSlugs = filteredSlugs.join(', ');
+
+      console.log(`${chalk.blue('-')} Datasources where slug starts with ${bySlug}: ${formattedSlugs}`);
+    }
+
+    if (byName) {
+      datasources = datasources.filter(datasource => datasource.name.toLowerCase().startsWith(byName.toLowerCase()));
+      const filteredNames = datasources.map(obj => obj.name);
+      const formattedNames = filteredNames.join(', ');
+
+      console.log(`${chalk.blue('-')} Datasources where name starts with ${byName}: ${formattedNames}`);
+    }
+
+    for (const datasource of datasources) {
+      console.log(`${chalk.blue('-')} Deleting ${datasource.name}`)
+      await api.deleteDatasource(datasource.id)
+    }
+
+  } catch (e) {
+    console.error(`${chalk.red('X')} An error ocurred in pull-components task when load components data`)
+    return Promise.reject(new Error(e))
+  }
+}
+
+module.exports = pullComponents

--- a/src/tasks/index.js
+++ b/src/tasks/index.js
@@ -11,5 +11,6 @@ module.exports = {
   listSpaces: require('./list-spaces'),
   importFiles: require('./import/import'),
   deleteComponent: require('./delete-component'),
-  deleteComponents: require('./delete-components')
+  deleteComponents: require('./delete-components'),
+  deleteDatasources: require('./delete-datasources')
 }

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -235,6 +235,24 @@ module.exports = {
       .catch(err => Promise.reject(err))
   },
 
+  getDatasources () {
+    const client = this.getClient()
+
+    return client
+      .get(this.getPath('datasources'))
+      .then(data => data.data.datasources || [])
+      .catch(err => Promise.reject(err))
+  },
+
+  deleteDatasource (id) {
+    const client = this.getClient()
+
+    return client
+      .delete(this.getPath(`datasources/${id}`))
+      .catch(err => Promise.reject(err))
+  },
+
+
   post (path, props) {
     return this.sendRequest(path, 'post', props)
   },


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [INT-](url)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

The delete-datasources command enables you to remove all datasources within the designated space. By utilizing the --by-slug option, you can filter the datasources based on their slugs, selectively deleting specific datasources. Similarly, the --by-name option functions in the same way, allowing you to filter and delete datasources based on their names.

`storyblok delete-datasources --space-id <SPACE_ID> # Will delete all datasources`
`storyblok delete-datasources --space-id <SPACE_ID> --by-slug global-translations   # Will only delete datasources where the slug starts with global-translations`

1. Verify the command availability: Confirm that the delete-datasources command with the --by-slug and --by-name options is available in the CLI tool or interface you are using.
2. Test scenario 1 - Delete all datasources: Execute the delete-datasources command without any additional options to delete all datasources within the specified space. Verify that all datasources are indeed deleted and the space is empty.
3. Test scenario 2 - Delete by slug: Use the --by-slug option to specify a particular slug value and execute the delete-datasources command. Confirm that only the datasources matching the provided slug are deleted, while other datasources remain unaffected.
4. Test scenario 3 - Delete by name: Utilize the --by-name option to specify a specific name and run the delete-datasources command. Validate that only the datasources with the specified name are deleted, while other datasources persist. 
5. Perform edge cases: Execute the commands with various edge cases, such as non-existent slugs or names, multiple matching datasources, and combinations of options, to ensure the behavior is as expected in different scenarios.

## What is the new behavior?

1. `delete-datasources` command: The command should allow you to delete all datasources within the specified space.
2. `--by-slug` option: When using the `--by-slug` option, you should be able to filter the datasources based on their slugs. Only the datasources matching the provided slug value should be deleted, while others remain unaffected.
3. `--by-name` option: With the `--by-name` option, you should be able to filter the datasources by their names. Only the datasources with the specified name should be deleted, while the rest should remain untouched.

In summary, the expected behavior is that the `delete-datasources` command, along with the `--by-slug` and `--by-name` options, should allow for selective deletion of datasources based on slug and/or name filters, while preserving other datasources in the specified space.
## Other information
