### PR TITLE
Add publish flag for rollback command

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,10 @@ $ storyblok rollback-migration --space 1234 --component Product --field title
 * `space`: the space you get from the space settings area
 * `component`: component name. It needs to be a valid component
 * `field`: name of field
+* `publish` (optional): publish the content when update
+  * `all`: publish all stories, even if they have not yet been published
+  * `published`: only publish stories that already are published and don't have unpublished changes
+  * `published-with-changes`: publish stories that are published and have unpublished changes
 
 ### spaces
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -418,12 +418,24 @@ program
   .description('Rollback-migration a migration file')
   .requiredOption('-c, --component <COMPONENT_NAME>', 'Name of the component')
   .requiredOption('-f, --field <FIELD_NAME>', 'Name of the component field')
+  .option('--publish <PUBLISH_OPTION>', 'Publish the content. It can be: all, published or published-with-changes')
   .action(async (options) => {
     const field = options.field || ''
     const component = options.component || ''
+    const publish = options.publish || null
     const space = program.space
     if (!space) {
       console.log(chalk.red('X') + ' Please provide the space as argument --space YOUR_SPACE_ID.')
+      process.exit(1)
+    }
+
+    const publishOptionsAvailable = [
+      'all',
+      'published',
+      'published-with-changes'
+    ]
+    if (publish && !publishOptionsAvailable.includes(publish)) {
+      console.log(chalk.red('X') + ' Please provide a correct publish option: all, published, or published-with-changes')
       process.exit(1)
     }
 
@@ -434,7 +446,7 @@ program
 
       api.setSpaceId(space)
 
-      await tasks.rollbackMigration(api, field, component)
+      await tasks.rollbackMigration(api, field, component, { publish })
     } catch (e) {
       console.log(chalk.red('X') + ' An error ocurred when run rollback-migration: ' + e.message)
       process.exit(1)

--- a/src/cli.js
+++ b/src/cli.js
@@ -13,7 +13,7 @@ const pkg = require('../package.json')
 
 const tasks = require('./tasks')
 const { getQuestions, lastStep, api, creds } = require('./utils')
-const { SYNC_TYPES, COMMANDS } = require('./constants')
+const { SYNC_TYPES, PUBLISH_TYPES, COMMANDS } = require('./constants')
 
 clear()
 console.log(chalk.cyan(figlet.textSync('storyblok')))
@@ -383,12 +383,7 @@ program
       process.exit(1)
     }
 
-    const publishOptionsAvailable = [
-      'all',
-      'published',
-      'published-with-changes'
-    ]
-    if (publish && !publishOptionsAvailable.includes(publish)) {
+    if (publish && !PUBLISH_TYPES.includes(publish)) {
       console.log(chalk.red('X') + ' Please provide a correct publish option: all, published, or published-with-changes')
       process.exit(1)
     }
@@ -429,12 +424,7 @@ program
       process.exit(1)
     }
 
-    const publishOptionsAvailable = [
-      'all',
-      'published',
-      'published-with-changes'
-    ]
-    if (publish && !publishOptionsAvailable.includes(publish)) {
+    if (publish && !PUBLISH_TYPES.includes(publish)) {
       console.log(chalk.red('X') + ' Please provide a correct publish option: all, published, or published-with-changes')
       process.exit(1)
     }

--- a/src/constants.js
+++ b/src/constants.js
@@ -12,6 +12,12 @@ const SYNC_TYPES = [
   'datasources'
 ]
 
+const PUBLISH_TYPES = [
+  'all',
+  'published',
+  'published-with-changes'
+]
+
 const COMMANDS = {
   GENERATE_MIGRATION: 'generate-migration',
   IMPORT: 'import',
@@ -33,6 +39,7 @@ module.exports = {
   SIGNUP_URL,
   API_URL,
   SYNC_TYPES,
+  PUBLISH_TYPES,
   US_API_URL,
   CN_API_URL,
   COMMANDS

--- a/src/tasks/migrations/rollback.js
+++ b/src/tasks/migrations/rollback.js
@@ -3,26 +3,11 @@ const fs = require('fs-extra')
 const MIGRATIONS_ROLLBACK_DIRECTORY = `${process.cwd()}/migrations/rollback`
 const {
   checkExistenceFilesInRollBackDirectory,
-  urlTofRollbackMigrationFile
+  urlTofRollbackMigrationFile,
+  isStoryPublishedWithoutChanges,
+  isStoryWithUnpublishedChanges
 } = require('./utils')
 
-/**
- * @method isStoryPublishedWithoutChanges
- * @param  {Object} story
- * @return {Boolean}
- */
-const isStoryPublishedWithoutChanges = story => {
-  return story.published && !story.unpublished_changes
-}
-
-/**
- * @method isStoryWithUnpublishedChanges
- * @param  {Object} story
- * @return {Boolean}
- */
-const isStoryWithUnpublishedChanges = story => {
-  return story.published && story.unpublished_changes
-}
 /**
  * @typedef {'all'|'published'|'published-with-changes'} PublishOptions
  *

--- a/src/tasks/migrations/run.js
+++ b/src/tasks/migrations/run.js
@@ -7,26 +7,10 @@ const {
   processMigration,
   getStoriesByComponent,
   getNameOfMigrationFile,
-  createRollbackFile
+  createRollbackFile,
+  isStoryPublishedWithoutChanges,
+  isStoryWithUnpublishedChanges
 } = require('./utils')
-
-/**
- * @method isStoryPublishedWithoutChanges
- * @param  {Object} story
- * @return {Boolean}
- */
-const isStoryPublishedWithoutChanges = story => {
-  return story.published && !story.unpublished_changes
-}
-
-/**
- * @method isStoryWithUnpublishedChanges
- * @param  {Object} story
- * @return {Boolean}
- */
-const isStoryWithUnpublishedChanges = story => {
-  return story.published && story.unpublished_changes
-}
 
 /**
  * @typedef {'all'|'published'|'published-with-changes'} PublishOptions

--- a/src/tasks/migrations/utils.js
+++ b/src/tasks/migrations/utils.js
@@ -318,6 +318,24 @@ const checkExistenceFilesInRollBackDirectory = (path, component, field) => {
   return Promise.resolve(file)
 }
 
+/**
+ * @method isStoryPublishedWithoutChanges
+ * @param  {Object} story
+ * @return {Boolean}
+ */
+const isStoryPublishedWithoutChanges = story => {
+  return story.published && !story.unpublished_changes
+}
+
+/**
+ * @method isStoryWithUnpublishedChanges
+ * @param  {Object} story
+ * @return {Boolean}
+ */
+const isStoryWithUnpublishedChanges = story => {
+  return story.published && story.unpublished_changes
+}
+
 module.exports = {
   getPathToFile,
   checkFileExists,
@@ -332,5 +350,7 @@ module.exports = {
   createRollbackFile,
   checkExistenceFilesInRollBackDirectory,
   urlTofRollbackMigrationFile,
-  getNameOfRollbackMigrationFile
+  getNameOfRollbackMigrationFile,
+  isStoryPublishedWithoutChanges,
+  isStoryWithUnpublishedChanges
 }

--- a/src/utils/last-step.js
+++ b/src/utils/last-step.js
@@ -49,7 +49,7 @@ const lastStep = answers => {
     console.log(chalk.green('✓') + ' - The github repository ' + gitRepo + ' will be cloned now...')
 
     ghdownload(gitRepo, outputDir, async (err) => {
-      if(err) {
+      if (err) {
         if (err.code === 'ENOTEMPTY') {
           console.log(chalk.red('  Oh Snap! It seems that you already have a project with the name: ' + name))
           reject(new Error('This repository already has been cloned'))


### PR DESCRIPTION
## Pull request type

Jira Link: N/A

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

You need to rollback a migration and observe that content after is being published (previously, rollback content was in "Draft" state).

## What is the new behavior?

- new `publish` flag for `rollback-migration` was added
- user now has an option to publish his content after running the rollback command

## Other information

Based on [this issue](https://github.com/storyblok/storyblok-cli/issues/9)