### PR TITLE
Change required node version to 18

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ We added the `region` option upon login. If you are using the CLI, please `logou
 
 ## Installation
 
-Make sure you have Node `>= 9.11.0` installed.
+Make sure you have Node `>= 18.0.0` installed.
 
 ```sh
 $ npm i storyblok -g

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "storyblok",
-  "version": "3.15.0",
+  "version": "3.25.0",
   "description": "A simple CLI to start Storyblok from your command line.",
   "repository": {
     "type": "git",
@@ -47,7 +47,7 @@
     "xml-js": "^1.6.11"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=18.0.0"
   },
   "devDependencies": {
     "concat-stream": "^2.0.0",


### PR DESCRIPTION
## Pull request type

Jira Link: N/A

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

In #60 the storyblok-js-client has been updated to version 5, this version requires that the environment supports fetch natively (node 18), this PR bumps the required version to 18 so you can only install this package on the correct environment

This fixes #61 (By forcing the user to use a newer node version)

## What is the new behavior?

A breaking change that requires a minimum of node 18 for the last version of the CLI

## Other information
