### PR TITLE
fix: add the correct way to get the paginated content for datasources

### DIFF
--- a/src/tasks/sync-commands/datasources.js
+++ b/src/tasks/sync-commands/datasources.js
@@ -46,7 +46,7 @@ class SyncDatasources {
       const entriesFirstPage = await this.client.get(`spaces/${spaceId}/datasource_entries/?datasource_id=${datasourceId}${dimensionQuery}`)
       const entriesRequets = []
       for (let i = 2; i <= Math.ceil(entriesFirstPage.total / 25); i++) {
-        entriesRequets.push(this.client.get(`spaces/${spaceId}/datasource_entries/?datasource_id=${datasourceId}`, { page: i }))
+        entriesRequets.push(await this.client.get(`spaces/${spaceId}/datasource_entries/?datasource_id=${datasourceId}&page=${i}`))
       }
       return entriesFirstPage.data.datasource_entries.concat(...(await Promise.all(entriesRequets)).map(r => r.data.datasource_entries))
     } catch (err) {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [INT-](url)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:-->

- [x] Bugfix

## How to test this PR

Reported here => https://github.com/storyblok/storyblok-cli/issues/66

## What is the new behavior?

- Now it's possible to sync more than 25 datasource entries

## Other information
