### PR TITLE
fix(int-1035): Storyblok cli is only syncing the first 25 entries from the datasources dimensions

### DIFF
--- a/src/tasks/sync-commands/datasources.js
+++ b/src/tasks/sync-commands/datasources.js
@@ -46,7 +46,7 @@ class SyncDatasources {
       const entriesFirstPage = await this.client.get(`spaces/${spaceId}/datasource_entries/?datasource_id=${datasourceId}${dimensionQuery}`)
       const entriesRequets = []
       for (let i = 2; i <= Math.ceil(entriesFirstPage.total / 25); i++) {
-        entriesRequets.push(await this.client.get(`spaces/${spaceId}/datasource_entries/?datasource_id=${datasourceId}&page=${i}`))
+        entriesRequets.push(await this.client.get(`spaces/${spaceId}/datasource_entries?datasource_id=${datasourceId}&page=${i}${dimensionQuery}`))
       }
       return entriesFirstPage.data.datasource_entries.concat(...(await Promise.all(entriesRequets)).map(r => r.data.datasource_entries))
     } catch (err) {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [INT-1035](https://storyblok.atlassian.net/browse/INT-1035)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:-->

- [x] Bugfix

## How to test this PR

Try to sync datasources between spaces, now the CLI need to sync all dimensions inside a datasource not only the first 25

```sh
storybook sync --type datasources --source 12345 --target  65432
```

## What is the new behavior?

- All dimensions are being updated

## Other information


[INT-1035]: https://storyblok.atlassian.net/browse/INT-1035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ