### PR TITLE
feat: fix the release workflow and publish the region-helper functionality

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20.11
           cache: 'yarn'
       - name: Install dependencies
         run: yarn


### PR DESCRIPTION
The release workflow is failing due to the required node version for working with the `semantic-release` package.

![image](https://github.com/storyblok/storyblok-cli/assets/1240591/0804b1cc-cc6b-48ba-931e-0cab15649d35)

More details about the error can be [checked here](https://github.com/storyblok/storyblok-cli/actions/runs/8164889154/job/22321056437)

## Pull request type

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Other (please describe): It adjusts only the CI/CD to work again with the semantic-release package.

## How to test this PR

## What is the new behavior?

## Other information
