### PR TITLE
Feature/shape 2922

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ $ storyblok sync --type <COMMAND> --source <SPACE_ID> --target <SPACE_ID>
 * `filter`: sync stories based on the given filter. Required Options: Required options: `--keys`, `--operations`, `--values`
 * `keys`: Multiple keys should be separated by comma. Example: `--keys key1,key2`, `--keys key1`
 * `operations`: Operations to be used for filtering. Can be: `is`, `in`, `not_in`, `like`, `not_like`, `any_in_array`, `all_in_array`, `gt_date`, `lt_date`, `gt_int`, `lt_int`, `gt_float`, `lt_float`. Multiple operations should be separated by comma.
+* `components-full-sync`: If used, the CLI will override the full component object when synching across spaces.
 
 #### Examples
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -327,6 +327,7 @@ program
       } = options;
 
       const _componentsGroups = componentsGroups ? componentsGroups.split(",") : null;
+      const _componentsFullSync = !!componentsFullSync;
       const filterQuery = filter ? buildFilterQuery(keys, operations, values) : undefined
       const token = creds.get().token || null;
 
@@ -345,7 +346,7 @@ program
         startsWith,
         filterQuery,
         _componentsGroups,
-        componentsFullSync,
+        _componentsFullSync,
       });
 
       console.log("\n" + chalk.green("✓") + " Sync data between spaces successfully completed");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -304,6 +304,7 @@ program
   .option('--operations <OPERATIONS>', 'Operations to be used for filtering. Can be: is, in, not_in, like, not_like, any_in_array, all_in_array, gt_date, lt_date, gt_int, lt_int, gt_float, lt_float. Multiple operations should be separated by comma.')
   .option('--values <VALUES>', 'Values to be used for filtering. Any string or number. If you want to use multiple values, separate them with a comma. Multiple values should be separated by comma.')
   .option("--components-groups <UUIDs>", "Synchronize components based on their group UUIDs separated by commas")
+  .option("--components-full-sync", "Synchronize components by overriding any property from source to target")
   .action(async (options) => {
     console.log(`${chalk.blue("-")} Sync data between spaces\n`);
 
@@ -321,10 +322,12 @@ program
         keys,
         operations,
         values,
-        componentsGroups
+        componentsGroups,
+        componentsFullSync
       } = options;
 
       const _componentsGroups = componentsGroups ? componentsGroups.split(",") : null;
+      console.log(componentsFullSync)
       const filterQuery = filter ? buildFilterQuery(keys, operations, values) : undefined
       const token = creds.get().token || null;
 
@@ -343,6 +346,7 @@ program
         startsWith,
         filterQuery,
         _componentsGroups,
+        componentsFullSync,
       });
 
       console.log("\n" + chalk.green("✓") + " Sync data between spaces successfully completed");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -327,7 +327,6 @@ program
       } = options;
 
       const _componentsGroups = componentsGroups ? componentsGroups.split(",") : null;
-      console.log(componentsFullSync)
       const filterQuery = filter ? buildFilterQuery(keys, operations, values) : undefined
       const token = creds.get().token || null;
 

--- a/src/tasks/sync-commands/components.js
+++ b/src/tasks/sync-commands/components.js
@@ -202,7 +202,6 @@ class SyncComponents {
   }
 
   mergeComponents (sourceComponent, targetComponent = {}) {
-    console.log(this.componentsFullSync)
     const data = this.componentsFullSync ? {
       ...sourceComponent
     } : {

--- a/src/tasks/sync-commands/components.js
+++ b/src/tasks/sync-commands/components.js
@@ -203,6 +203,7 @@ class SyncComponents {
 
   mergeComponents (sourceComponent, targetComponent = {}) {
     const data = this.componentsFullSync ? {
+      // This should be the default behavior in a major future version
       ...sourceComponent
     } : {
       ...sourceComponent,

--- a/src/tasks/sync-commands/components.js
+++ b/src/tasks/sync-commands/components.js
@@ -20,6 +20,7 @@ class SyncComponents {
     this.client = api.getClient()
     this.presetsLib = new PresetsLib({ oauthToken: options.oauthToken, targetSpaceId: this.targetSpaceId })
     this.componentsGroups = options.componentsGroups
+    this.componentsFullSync = options.componentsFullSync
   }
 
   async sync () {
@@ -201,7 +202,10 @@ class SyncComponents {
   }
 
   mergeComponents (sourceComponent, targetComponent = {}) {
-    const data = {
+    console.log(this.componentsFullSync)
+    const data = this.componentsFullSync ? {
+      ...sourceComponent
+    } : {
       ...sourceComponent,
       ...targetComponent
     }

--- a/src/tasks/sync.js
+++ b/src/tasks/sync.js
@@ -16,7 +16,7 @@ const SyncSpaces = {
     this.targetSpaceId = options.target
     this.oauthToken = options.token
     this.componentsGroups = options._componentsGroups
-    this.componentsFullSync = options.componentsFullSync
+    this.componentsFullSync = options._componentsFullSync
     this.startsWith = options.startsWith
     this.filterQuery = options.filterQuery
   },

--- a/src/tasks/sync.js
+++ b/src/tasks/sync.js
@@ -16,6 +16,7 @@ const SyncSpaces = {
     this.targetSpaceId = options.target
     this.oauthToken = options.token
     this.componentsGroups = options._componentsGroups
+    this.componentsFullSync = options.componentsFullSync
     this.startsWith = options.startsWith
     this.filterQuery = options.filterQuery
   },
@@ -232,7 +233,8 @@ const SyncSpaces = {
       sourceSpaceId: this.sourceSpaceId,
       targetSpaceId: this.targetSpaceId,
       oauthToken: this.oauthToken,
-      componentsGroups: this.componentsGroups
+      componentsGroups: this.componentsGroups,
+      componentsFullSync: this.componentsFullSync
     })
     
     try {


### PR DESCRIPTION
This PR fixes a very old design flaw of the CLI: when running the `sync` command, components will be synched only partially when they already exist, so display name, icon, preview, and any other property, except presets and fields, won't be synched into the target space. 
This PR adds a new parameter called `--components-full-sync` to synch every property of the components. The decision to use a parameter is because this bug has been here for 4 years, so it can be considered a breaking change. I don't think we should create a new major release for this, so I'm just adding a parameter with the intention of making this the default behavior in a future major version.

## Pull request type

Jira Link: [SHAPE-2922](https://storyblok.atlassian.net/browse/SHAPE-2922)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

Create two spaces, then add a component to the source space and run 

```
npm run dev -- sync --type components --source SOURCE_SPACE_ID --target TARGET_SPACE_ID
```

Then, change the display name of your component in the source space and other properties of your choice (except for presets and fields), and run the above command again. These changes shouldn't be reflected in the target space. You can try it from the main branch, and you should get the same result.

Now run from the branch of this PR this command:

```
npm run dev -- sync --type components --source SOURCE_SPACE_ID --target TARGET_SPACE_ID --components-full-sync
```

You should get all of the changes from source into target.

## What is the new behavior?

The new `--components-full-sync` parameter will make the CLI sync all the properties of components into target when a components synch is executed.

## Other information


[SHAPE-2922]: https://storyblok.atlassian.net/browse/SHAPE-2922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ