### PR TITLE
fix: generate typescript types using camel case

### DIFF
--- a/src/utils/typescript/generateTypesFromJSONSchema.ts
+++ b/src/utils/typescript/generateTypesFromJSONSchema.ts
@@ -418,7 +418,7 @@ export class GenerateTypesFromJSONSchemas {
    */
   #getComponentType(componentName: string) {
     const componentType = startCase(
-      camelCase(`${this.#options.typeNamesPrefix ?? ""}${componentName}${this.#options.typeNamesSuffix}`)
+      camelCase(`${this.#options.typeNamesPrefix ?? ""}_${componentName}_${this.#options.typeNamesSuffix}`)
     ).replace(/ /g, "");
 
     /**


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [INT-](url)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR
<!-- Please provide the steps on how to test this PR. -->
In order to test these changes, just generate types using `storyblok generate-typescript-typedefs` with the `--typeNamesPrefix Prefix` flag. You will see that the types are now generated without violating Typescript's type naming convention when using `--typeNamesPrefix` flag. The issue was the usage of `lodash.camelCase`.


## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Without these changes, the generated output for a component named `component_name` would be `PrefixcomponentNameStoryblok` which is clearly violating Typescript's type naming convention.
- With these changes the types are named matching the Typescript type naming convention like `PrefixComponentNameStoryblok`.

## Other information
We are using the `--typeNamesPrefix` flag to match our typing schema. Therefore, we would be really thankful to get this changes in.