### PR TITLE
feat: CLI error message now gives more info about the error

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -618,7 +618,7 @@ function errorHandler(e, command) {
   } else {
     let errorMessage = e.message;
     
-    if (!errorMessage && e instance of Error) {
+    if (!errorMessage && e instanceof Error) {
       errorMessage = JSON.stringify(e);
     }
     

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -616,7 +616,13 @@ function errorHandler(e, command) {
         ` If your space was not created under ${EU_CODE} region, you must provide the region (${allRegionsButDefault}) upon login.`
     );
   } else {
-    console.log(chalk.red("X") + " An error occurred when executing the " + command + " task: " + e || e.message);
+    let errorMessage = e.message;
+    
+    if (!errorMessage && e instance of Error) {
+      errorMessage = JSON.stringify(e);
+    }
+    
+    console.log(chalk.red("X") + " An error occurred when executing the " + command + " task: " + errorMessage);
   }
   process.exit(1);
 }


### PR DESCRIPTION
## PR type
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR
1. Trigger a cli command that will trigger an error
2. You should see the error message instead of `Error [object Object]`

## What is the new behavior?
- `e.message` now takes precedence over the whole of the error object
- The error object is now stringified instead of showing `Error [object Object]`

## Other information
I recently ran the `pull-components` command and received this error message and I thought we could improve the `Error: [object Object]` part:
```
- Executing pull-components task
X An error ocurred in pull-components task when load components data
X An error occurred when executing the pull-components task: Error: [object Object]
```

I don't have a very broad understanding of the repo so please feel free to ask for a modification or do the necessary modifications if needed :) 