### PR TITLE
Fix/pro 173

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,12 +96,14 @@ $ storyblok pull-languages --space <SPACE_ID>
 
 Download your space's components schema as json. By default this command will download 2 files: 1 for the components and 1 for the presets; But if you pass a flag `--separate-files or --sf` the command will create file for each component and presets. And also you could pass a path `--path or -p` to save your components and presets.
 
+It's highly recommended to use also the `--prefix-presets-names` or `-ppn` parameter if you use `--separate-files` because it will prefix the names of the individual files with the name of the component. This feature solves the issue of multiple presets from different compoentns but with the same name, being written in the same file. In a future major version this will become the default behavior.
+
 ```sh
 $ storyblok pull-components --space <SPACE_ID> # Will save files like components-1234.json
 ```
 
 ```sh
-$ storyblok pull-components --space <SPACE_ID> --separate-files  --file-name production # Will save files like feature-production.json grid-production.json
+$ storyblok pull-components --space <SPACE_ID> --separate-files --prefix-presets-names --file-name production # Will save files like feature-production.json grid-production.json
 ```
 
 #### Options

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ $ storyblok pull-languages --space <SPACE_ID>
 
 Download your space's components schema as json. By default this command will download 2 files: 1 for the components and 1 for the presets; But if you pass a flag `--separate-files or --sf` the command will create file for each component and presets. And also you could pass a path `--path or -p` to save your components and presets.
 
-It's highly recommended to use also the `--prefix-presets-names` or `-ppn` parameter if you use `--separate-files` because it will prefix the names of the individual files with the name of the component. This feature solves the issue of multiple presets from different compoentns but with the same name, being written in the same file. In a future major version this will become the default behavior.
+It's highly recommended to use also the `--prefix-presets-names` or `-ppn` parameter if you use `--separate-files` because it will prefix the names of the individual files with the name of the component. This feature solves the issue of multiple presets from different components but with the same name, being written in the same file. In a future major version this will become the default behavior.
 
 ```sh
 $ storyblok pull-components --space <SPACE_ID> # Will save files like components-1234.json

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -142,11 +142,12 @@ program
   .option("--sf, --separate-files [value]", "Argument to create a single file for each component")
   .option("-p, --path <path>", "Path to save the component files")
   .option("-f, --file-name <fileName>", "custom name to be used in file(s) name instead of space id")
+  .option("-ppn, --prefix-presets-names", "Prefixes the names of presets with the name of the components")
   .description("Download your space's components schema as json")
   .action(async (options) => {
     console.log(`${chalk.blue("-")} Executing pull-components task`);
     const space = program.space;
-    const { separateFiles, path } = options;
+    const { separateFiles, path, prefixPresetsNames } = options;
     if (!space) {
       console.log(chalk.red("X") + " Please provide the space as argument --space YOUR_SPACE_ID.");
       process.exit(0);
@@ -160,7 +161,7 @@ program
       }
 
       api.setSpaceId(space);
-      await tasks.pullComponents(api, { fileName, separateFiles, path });
+      await tasks.pullComponents(api, { fileName, separateFiles, path, prefixPresetsNames });
     } catch (e) {
       errorHandler(e, COMMANDS.PULL_COMPONENTS);
     }

--- a/src/tasks/pull-components.js
+++ b/src/tasks/pull-components.js
@@ -24,7 +24,7 @@ const getNameFromComponentGroups = (groups, uuid) => {
  * @return {Promise<Object>}
  */
 const pullComponents = async (api, options) => {
-  const { fileName, separateFiles, path } = options
+  const { fileName, separateFiles, path, prefixPresetsNames } = options
 
   try {
     const componentGroups = await api.getComponentGroups()
@@ -52,7 +52,7 @@ const pullComponents = async (api, options) => {
       if (presets.length === 0) return
 
       for (const preset in presets) {
-        const presetFileName = `${presets[preset].name}-${fileName}.json`
+        const presetFileName = `${prefixPresetsNames ? `${presets[preset].preset.component}-` : ""}${presets[preset].name}-${fileName}.json`
         const data = JSON.stringify(presets[preset], null, 2)
         saveFileFactory(presetFileName, data, path)
       }

--- a/src/utils/save-file-factory.js
+++ b/src/utils/save-file-factory.js
@@ -1,6 +1,6 @@
 import fs from 'fs'
 
-const saveFileFactory = (fileName, content, path = './temp/') => {
+const saveFileFactory = (fileName, content, path = './') => {
   try {
     fs.writeFileSync(`${path}${fileName}`, content);
     return true;

--- a/src/utils/save-file-factory.js
+++ b/src/utils/save-file-factory.js
@@ -1,16 +1,13 @@
 import fs from 'fs'
 
-const saveFileFactory = async (fileName, content, path = './') => {
-  return new Promise((resolve, reject) => {
-    fs.writeFile(`${path}${fileName}`, content, err => {
-      if (err) {
-        Promise.reject(err)
-        return
-      }
-
-      Promise.resolve(true)
-    })
-  })
+const saveFileFactory = (fileName, content, path = './temp/') => {
+  try {
+    fs.writeFileSync(`${path}${fileName}`, content);
+    return true;
+  } catch(err) {
+    console.log(err);
+    return false;
+  }
 }
 
 export default saveFileFactory

--- a/tests/units/pull-components.spec.js
+++ b/tests/units/pull-components.spec.js
@@ -3,7 +3,7 @@ import pullComponents from '../../src/tasks/pull-components'
 import { FAKE_PRESET, FAKE_COMPONENTS } from '../constants'
 import { jest } from '@jest/globals'
 
-jest.spyOn(fs, 'writeFile').mockImplementation(jest.fn((key, data, _) => {
+jest.spyOn(fs, 'writeFileSync').mockImplementation(jest.fn((key, data, _) => {
   [key] = data
 }))
 
@@ -25,7 +25,7 @@ describe('testing pullComponents', () => {
     expect(api.getComponents.mock.calls.length).toBe(1)
   })
 
-  it('pull components should be call fs.writeFile correctly and generate component file', async () => {
+  it('pull components should be call fs.writeFileSync correctly and generate component file', async () => {
     const SPACE = 12345
 
     const api = {
@@ -47,14 +47,14 @@ describe('testing pullComponents', () => {
     const expectFileName = `components.${SPACE}.json`
 
     await pullComponents(api, options)
-    const [path, data] = fs.writeFile.mock.calls[0]
+    const [path, data] = fs.writeFileSync.mock.calls[0]
 
-    expect(fs.writeFile.mock.calls.length).toBe(1)
+    expect(fs.writeFileSync.mock.calls.length).toBe(1)
     expect(path).toBe(`./${expectFileName}`)
     expect(JSON.parse(data)).toEqual({ components: [FAKE_COMPONENTS()[0]] })
   })
 
-  it('pull components should be call fs.writeFile correctly and generate a component and preset files', async () => {
+  it('pull components should be call fs.writeFileSync correctly and generate a component and preset files', async () => {
     const SPACE = 12345
 
     const api = {
@@ -77,10 +77,10 @@ describe('testing pullComponents', () => {
     const expectPresetFileName = `presets.${SPACE}.json`
 
     await pullComponents(api, options)
-    const [compPath, compData] = fs.writeFile.mock.calls[0]
-    const [presetPath, presetData] = fs.writeFile.mock.calls[1]
+    const [compPath, compData] = fs.writeFileSync.mock.calls[0]
+    const [presetPath, presetData] = fs.writeFileSync.mock.calls[1]
 
-    expect(fs.writeFile.mock.calls.length).toBe(2)
+    expect(fs.writeFileSync.mock.calls.length).toBe(2)
 
     expect(compPath).toBe(`./${expectComponentFileName}`)
     expect(JSON.parse(compData)).toEqual({ components: [FAKE_COMPONENTS()[0]] })
@@ -89,7 +89,7 @@ describe('testing pullComponents', () => {
     expect(JSON.parse(presetData)).toEqual({ presets: FAKE_PRESET() })
   })
 
-  it('pull components should be call fs.writeFile and generate a single file for each component', async () => {
+  it('pull components should be call fs.writeFileSync and generate a single file for each component', async () => {
     const SPACE = 12345
 
     const api = {
@@ -110,12 +110,12 @@ describe('testing pullComponents', () => {
     }
 
     await pullComponents(api, options)
-    expect(fs.writeFile.mock.calls.length).toBe(FAKE_COMPONENTS().length)
+    expect(fs.writeFileSync.mock.calls.length).toBe(FAKE_COMPONENTS().length)
 
     for (const comp in FAKE_COMPONENTS()) {
       const fileName = `${FAKE_COMPONENTS()[comp].name}-${SPACE}.json`
       let data = FAKE_COMPONENTS()[comp]
-      const [compPath, compData] = fs.writeFile.mock.calls[comp]
+      const [compPath, compData] = fs.writeFileSync.mock.calls[comp]
 
       if (FAKE_COMPONENTS()[comp].name === 'logo') {
         data = { ...FAKE_COMPONENTS()[comp], component_group_name: '' }


### PR DESCRIPTION
This PR fixes some problems that happen when running `pull-components` with the `--separate-files` parameter. Some files will be corrupted during the asynchronous save. The code of the CLI doesn't even wait for the writing operation to be over.

## Pull request type

Jira Link: [INT-](url)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

In the same parent folder as the `storyblok-cli` one, create one called `data`, then run:
Run `npm run dev pull-components -- --space 88751 --separate-files --path ./../data/`
You should get no errors. Now open any JSON file and inspect the content. The content should be correct.

## What is the new behavior?

Files from `pull-components` command are stored synchronously

## Other information
