### PR TITLE
[PRO-284] fix support sync component internal tags

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,13 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+      {
+          "type": "node",
+          "request": "launch",
+          "name": "Launch CLI Script",
+          "skipFiles": ["<node_internals>/**"],
+          "program": "${workspaceFolder}/dist/cli.mjs",
+          "args": ["sync", "--type", "components", "--source", "295017", "--target", "295018"]
+      }
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,13 +1,23 @@
 {
   "version": "0.2.0",
   "configurations": [
-      {
-          "type": "node",
-          "request": "launch",
-          "name": "Launch CLI Script",
-          "skipFiles": ["<node_internals>/**"],
-          "program": "${workspaceFolder}/dist/cli.mjs",
-          "args": ["sync", "--type", "components", "--source", "295017", "--target", "295018"]
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Jest Tests",
+      "runtimeArgs": [
+        "--experimental-vm-modules"
+      ],
+      "args": [
+        "--silent",
+        "--runInBand"
+      ],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "program": "${workspaceFolder}/node_modules/.bin/jest",
+      "windows": {
+        "program": "${workspaceFolder}\\node_modules\\jest\\bin\\jest.js"
       }
+    }
   ]
 }

--- a/src/tasks/sync-commands/components.js
+++ b/src/tasks/sync-commands/components.js
@@ -145,13 +145,13 @@ class SyncComponents {
 
           const componentTarget = this.getTargetComponent(component.name)
 
-          const updatedComponent = await this.updateComponent(
+          await this.updateComponent(
             this.targetSpaceId,
             componentTarget.id,
             componentData,
             componentTarget
           )
-          console.log(chalk.green('✓') + ` Component ${updatedComponent.name} synced`)
+          console.log(chalk.green('✓') + ` Component ${component.name} synced`)
 
           const presetsToSave = this.presetsLib.filterPresetsFromTargetComponent(
             componentPresets || [],

--- a/tests/constants.js
+++ b/tests/constants.js
@@ -23,6 +23,8 @@ export const FAKE_COMPONENTS = () => [
     preview_tmpl: null,
     is_nestable: true,
     all_presets: [],
+    internal_tag_ids: [],
+    internal_tags_list: [],
     preset_id: null,
     real_name: 'teaser',
     component_group_uuid: null
@@ -56,6 +58,8 @@ export const FAKE_COMPONENTS = () => [
     preview_tmpl: null,
     is_nestable: true,
     all_presets: [],
+    internal_tag_ids: [],
+    internal_tags_list: [],
     preset_id: null,
     real_name: 'feature',
     component_group_uuid: null
@@ -75,6 +79,8 @@ export const FAKE_COMPONENTS = () => [
     preview_tmpl: null,
     is_nestable: true,
     all_presets: [],
+    internal_tag_ids: [],
+    internal_tags_list: [],
     preset_id: null,
     real_name: 'logo',
     component_group_uuid: '529cc32a-1d97-4b4a-b0b6-28e33dc56c0d'
@@ -101,6 +107,8 @@ export const FAKE_COMPONENTS = () => [
     preview_tmpl: null,
     is_nestable: true,
     all_presets: [],
+    internal_tag_ids: [],
+    internal_tags_list: [],
     preset_id: null,
     real_name: 'blocks',
     component_group_uuid: null
@@ -132,6 +140,8 @@ export const FAKE_COMPONENTS = () => [
         image: null
       }
     ],
+    internal_tag_ids: [],
+    internal_tags_list: [],
     preset_id: null,
     real_name: 'hero',
     component_group_uuid: null

--- a/tests/units/sync-components.spec.js
+++ b/tests/units/sync-components.spec.js
@@ -43,6 +43,8 @@ const FAKE_COMPONENTS_TO_TEST = {
           preview_tmpl: null,
           is_nestable: true,
           all_presets: [],
+          internal_tag_ids: [],
+          internal_tags_list: [],
           preset_id: null,
           real_name: 'feature',
           component_group_uuid: null
@@ -62,9 +64,23 @@ const FAKE_COMPONENTS_TO_TEST = {
           preview_tmpl: null,
           is_nestable: true,
           all_presets: [],
+          internal_tag_ids: [],
+          internal_tags_list: [],
           preset_id: null,
           real_name: 'teaser',
           component_group_uuid: null
+        }
+      ],
+      internal_tags: [
+        {
+          id: 1,
+          name: 'tag1',
+          object_type: 'component',
+        },
+        {
+          id: 2,
+          name: 'tag2',
+          object_type: 'component',
         }
       ]
     }
@@ -132,6 +148,14 @@ const mockGetRequest = (path) => {
     return Promise.resolve(FAKE_COMPONENTS_TO_TEST[extractSpace(path)])
   }
 
+  if (
+    path === 'spaces/001/internal_tags' ||
+    path === 'spaces/002/internal_tags'
+  ) {
+    return Promise.resolve(FAKE_COMPONENTS_TO_TEST[extractSpace(path)])
+  }
+  
+
   if (path === 'spaces/001/presets') {
     return Promise.resolve(FAKE_PRESETS[extractSpace(path)])
   }
@@ -175,7 +199,13 @@ const mockPostRequest = (path, payload) => {
 }
 
 const mockPutRequest = (path, payload) => {
-  return Promise.resolve(true)
+  return Promise.resolve({
+    data: {
+      component: {
+        ...payload.component,
+      }
+    }
+  })
 }
 
 const spyGet = jest.spyOn(Storyblok.prototype, 'get').mockImplementation(mockGetRequest)
@@ -207,6 +237,14 @@ describe('testing syncComponents', () => {
       source: SOURCE_SPACE_TEST,
       target: TARGET_SPACE_TEST
     })
+  })
+
+  afterAll(() => {
+    spyGet.mockClear()
+    spyPost.mockClear()
+    spyPut.mockClear()
+    spyGetPresets.mockClear()
+    spyCreatePresets.mockClear()
   })
 
   it('shoud be get the all data correctly', () => {
@@ -245,6 +283,8 @@ describe('testing syncComponents', () => {
           display_name: null,
           id: 0,
           image: null,
+          internal_tag_ids: [],
+          internal_tags_list: [],
           is_nestable: true,
           is_root: false,
           name: 'teaser',
@@ -303,6 +343,8 @@ describe('testing syncComponents', () => {
           preview_tmpl: null,
           is_nestable: true,
           all_presets: [],
+          internal_tag_ids: [],
+          internal_tags_list: [],
           preset_id: null,
           real_name: 'logo',
           component_group_uuid: '000000002'


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

<!-- Please provide the steps on how to test this PR. -->

- Go to vscode
- Run & Debug tab
- Run "Launch CLI Script" 
- Check result on debug console.
- (Optional) Check the spaces directly  (295017, 295018)

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- [x] Added internal logic to handle component internal tags (Will only create tags on target if they don't exist yet)
- [x] Tested creation of new component with tags if it doesn't exist on target space
- [x] Tested update of component with tags if it already exists on target space

## Other information

I had to force the updated component `internal_tag_ids` to always be like the source component because the current solution `mergeComponents` is not recursive and is not merging the array correctly. I don't think is worth to refactor `mergeComponents` right now since we plan other things for this package in the near future.

```
 payload.component.internal_tag_ids = sourceComponentData.internal_tag_ids;
```

```ts
updateComponent(spaceId, componentId, sourceComponentData, targetComponentData) {
    const payload = {
      component: this.mergeComponents(
        sourceComponentData,
        targetComponentData
      )
    };
    payload.component.internal_tag_ids = sourceComponentData.internal_tag_ids;
    return this.client.put(`spaces/${spaceId}/components/${componentId}`, payload).then((response) => {
      const component = response.data.component || {};
      return component;
    }).catch((error) => Promise.reject(error));
  }
```

