### PR TITLE
fix: add support for string as a filter_content_type

### DIFF
--- a/src/types/generate-typescript-typedefs.ts
+++ b/src/types/generate-typescript-typedefs.ts
@@ -41,7 +41,7 @@ export type ComponentPropertySchema = {
   component_whitelist?: string[];
   email_link_type?: boolean;
   exclude_empty_option?: boolean;
-  filter_content_type?: string[];
+  filter_content_type?: string | string[];
   key: string;
   options?: ComponentPropertySchemaOption[];
   pos: number;

--- a/src/utils/typescript/generateTypesFromJSONSchema.ts
+++ b/src/utils/typescript/generateTypesFromJSONSchema.ts
@@ -342,6 +342,12 @@ export class GenerateTypesFromJSONSchemas {
 
     if (property.source === "internal_stories") {
       if (property.filter_content_type) {
+        if (typeof property.filter_content_type === "string") {
+          return {
+            tsType: `(${this.#getStoryType(property.filter_content_type)} | string )${property.type === "options" ? "[]" : ""}`,
+          };
+        }
+
         return {
           tsType: `(${property.filter_content_type
             .map((type2) => this.#getStoryType(type2))


### PR DESCRIPTION
Schema generated in the past may contain `filter_content_type` as a string, in contrast to newly generated ones that become an array of strings. This PR adds support to gracefully handle older string types.

This PR fixes #94 

## Pull request type

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):