### PR TITLE
fix: Update "already logged" error message

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -56,7 +56,7 @@ program
     if (api.isAuthorized()) {
       console.log(
         chalk.green("✓") +
-          " The user has been already logged. If you want to change the logged user, you must logout and login again"
+          " The user has been already logged in. If you want to change the logged user, you must logout and login again"
       );
       return;
     }


### PR DESCRIPTION
This does a minor update to make the "already logged (in)" error message make more sense 

## Pull request type

Jira Link: n/a

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

Run the `storyblok` login command again after logging in.

## What is the new behavior?

The error message will be more grammatically correct.

## Other information
