### PR TITLE
fix: PRO-615 push pull tag components

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,6 +18,17 @@
       "windows": {
         "program": "${workspaceFolder}\\node_modules\\jest\\bin\\jest.js"
       }
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug pull-components",
+      "program": "${workspaceFolder}/dist/cli.mjs",
+      "args": ["pull-components", "--space", "6274026"],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
+      "sourceMaps": true,
+      "outFiles": ["${workspaceFolder}/dist/**/*.js"]
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,7 +24,7 @@
       "request": "launch",
       "name": "Debug pull-components",
       "program": "${workspaceFolder}/dist/cli.mjs",
-      "args": ["pull-components", "--space", "6274026"],
+      "args": ["push-components", "components.295017.json", "--space", "295018"],
       "cwd": "${workspaceFolder}",
       "console": "integratedTerminal",
       "sourceMaps": true,


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Allow CLI to push components with tags

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

<!-- Please provide the steps on how to test this PR. -->
- Build project locally with `npm run build`
- Create a component with tags on Space A
- Pull components of source Space A with `node dist/cli.mjs pull-components --space=spaceAid`
- Push components to Space B with `node dist/cli.mjs push-components componentsSpaceAid.json --space=spaceBid`

You should see this:

![Screenshot 2024-09-12 at 10 39 15](https://github.com/user-attachments/assets/7e6e9c37-bffb-4bc9-a3fc-13c59b611590)

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information
