### PR TITLE
fix: use `.mjs` instead

### DIFF
--- a/src/tasks/migrations/utils.js
+++ b/src/tasks/migrations/utils.js
@@ -38,7 +38,7 @@ export const getPathToFile = (fileName, migrationPath = null) => {
  * getNameOfMigrationFile('product', 'price') // change_product_price
  */
 export const getNameOfMigrationFile = (component, field) => {
-  return `change_${component}_${field}.js`
+  return `change_${component}_${field}.mjs`
 }
 
 /**


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [INT-](url)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:-->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

- Run `node dist/cli.mjs generate-migration`
- Remove `type:module` from the root package.json
- Run  `node dist/cli.mjs run-migration`

## What is the new behavior?

- Migration files should be now `.mjs` and should run without errors

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information
