### PR TITLE
[PRO-658] - Update `Asset`, `Multiasset` and `Multilink` types

### DIFF
--- a/src/utils/typescript/storyblokProvidedPropertyTypes.ts
+++ b/src/utils/typescript/storyblokProvidedPropertyTypes.ts
@@ -4,27 +4,65 @@ export const getAssetJSONSchema = (title: string): JSONSchema => ({
   $id: "#/asset",
   title,
   type: "object",
-  required: ["id", "filename", "name"],
+  required: ["id", "fieldtype", "filename", "name", "title", "focus", "alt"],
   properties: {
     alt: {
-      type: "string",
+      type: ["string", "null"],
     },
     copyright: {
+      type: ["string", "null"],
+    },
+    fieldtype: {
       type: "string",
+      enum: ["asset"],
     },
     id: {
       type: "number",
     },
     filename: {
-      type: "string",
+      type: ["string", "null"],
     },
     name: {
       type: "string",
     },
     title: {
-      type: "string",
+      type: ["string", "null"],
     },
     focus: {
+      type: ["string", "null"],
+    },
+    meta_data: {
+      type: "object",
+    },
+    source: {
+      type: ["string", "null"],
+    },
+    is_external_url: {
+      type: "boolean",
+    },
+    is_private: {
+      type: "boolean",
+    },
+    src: {
+      type: "string",
+    },
+    updated_at: {
+      type: "string",
+    },
+    // Cloudinary integration keys
+    width: {
+      type: ["number", "null"],
+    },
+    height: {
+      type: ["number", "null"],
+    },
+    aspect_ratio: {
+      type: ["number", "null"],
+    },
+    public_id: {
+      type: ["string", "null"],
+    },
+    content_type: {
       type: "string",
     },
   },

--- a/src/utils/typescript/storyblokProvidedPropertyTypes.ts
+++ b/src/utils/typescript/storyblokProvidedPropertyTypes.ts
@@ -74,24 +74,65 @@ export const getMultiassetJSONSchema = (title: string): JSONSchema => ({
   type: "array",
   items: {
     type: "object",
-    required: ["id", "filename", "name"],
+    required: ["id", "fieldtype", "filename", "name", "title", "focus", "alt"],
     properties: {
       alt: {
-        type: "string",
+        type: ["string", "null"],
       },
       copyright: {
+        type: ["string", "null"],
+      },
+      fieldtype: {
         type: "string",
+        enum: ["asset"],
       },
       id: {
         type: "number",
       },
       filename: {
-        type: "string",
+        type: ["string", "null"],
       },
       name: {
         type: "string",
       },
       title: {
+        type: ["string", "null"],
+      },
+      focus: {
+        type: ["string", "null"],
+      },
+      meta_data: {
+        type: "object",
+      },
+      source: {
+        type: ["string", "null"],
+      },
+      is_external_url: {
+        type: "boolean",
+      },
+      is_private: {
+        type: "boolean",
+      },
+      src: {
+        type: "string",
+      },
+      updated_at: {
+        type: "string",
+      },
+      // Cloudinary integration keys
+      width: {
+        type: ["number", "null"],
+      },
+      height: {
+        type: ["number", "null"],
+      },
+      aspect_ratio: {
+        type: ["number", "null"],
+      },
+      public_id: {
+        type: ["string", "null"],
+      },
+      content_type: {
         type: "string",
       },
     },

--- a/src/utils/typescript/storyblokProvidedPropertyTypes.ts
+++ b/src/utils/typescript/storyblokProvidedPropertyTypes.ts
@@ -139,29 +139,43 @@ export const getMultiassetJSONSchema = (title: string): JSONSchema => ({
   },
 });
 
+// TODO: find a reliable way to share props among different Link Types to increase maintainability
+// Currently not possible because of JSONSchema4 complaining
+const multilinkSharedRequiredProps = ["fieldtype", "id", "url", "cached_url", "linktype"];
+
 export const getMultilinkJSONSchema = (title: string): JSONSchema => ({
   $id: "#/multilink",
   title,
   oneOf: [
     {
       type: "object",
+      required: multilinkSharedRequiredProps,
       properties: {
-        id: {
+        // Shared props
+        fieldtype: {
           type: "string",
+          enum: ["multilink"],
         },
-        cached_url: {
-          type: "string",
-        },
+        id: { type: "string" },
+        url: { type: "string" },
+        cached_url: { type: "string" },
+        target: { type: "string", enum: ["_blank", "_self"] },
+        // Custom props
         anchor: {
+          type: "string",
+        },
+        rel: {
+          type: "string",
+        },
+        title: {
+          type: "string",
+        },
+        prep: {
           type: "string",
         },
         linktype: {
           type: "string",
           enum: ["story"],
-        },
-        target: {
-          type: "string",
-          enum: ["_self", "_blank"],
         },
         story: {
           type: "object",
@@ -248,29 +262,44 @@ export const getMultilinkJSONSchema = (title: string): JSONSchema => ({
     },
     {
       type: "object",
+      required: multilinkSharedRequiredProps,
       properties: {
-        url: {
+        // Shared props
+        fieldtype: {
           type: "string",
+          enum: ["multilink"],
         },
-        cached_url: {
-          type: "string",
-        },
-        anchor: {
-          type: "string",
-        },
+        id: { type: "string" },
+        url: { type: "string" },
+        cached_url: { type: "string" },
+        target: { type: "string", enum: ["_blank", "_self"] },
+        // Custom props
         linktype: {
           type: "string",
-          enum: ["asset", "url"],
+          enum: ["url"],
         },
-        target: {
+        rel: {
           type: "string",
-          enum: ["_self", "_blank"],
+        },
+        title: {
+          type: "string",
         },
       },
     },
     {
       type: "object",
+      required: multilinkSharedRequiredProps,
       properties: {
+        // Shared props
+        fieldtype: {
+          type: "string",
+          enum: ["multilink"],
+        },
+        id: { type: "string" },
+        url: { type: "string" },
+        cached_url: { type: "string" },
+        target: { type: "string", enum: ["_blank", "_self"] },
+        // Custom props
         email: {
           type: "string",
         },
@@ -278,9 +307,25 @@ export const getMultilinkJSONSchema = (title: string): JSONSchema => ({
           type: "string",
           enum: ["email"],
         },
-        target: {
+      },
+    },
+    {
+      type: "object",
+      required: multilinkSharedRequiredProps,
+      properties: {
+        // Shared props
+        fieldtype: {
           type: "string",
-          enum: ["_self", "_blank"],
+          enum: ["multilink"],
+        },
+        id: { type: "string" },
+        url: { type: "string" },
+        cached_url: { type: "string" },
+        target: { type: "string", enum: ["_blank", "_self"] },
+        // Custom props
+        linktype: {
+          type: "string",
+          enum: ["asset"],
         },
       },
     },


### PR DESCRIPTION
This PR aims to fix the creation of `Asset`, `Multiasset` and `Multilink` field types created by the `generate-typescript-typedefs` command.

## Pull request type
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR
- Pull components' schema from a space
- Run `generate-typescript-typedefs` command against that schema

## What is the new behavior?
The types for `Asset`, `Multiasset` and `Multilink` should be up to date now.