### PR TITLE
Add slug parameter to migration template

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,7 +473,7 @@ The created file will have the following content:
 
 ```js
 // here, 'subtitle' is the name of the field defined when you execute the generate command
-module.exports = function (block) {
+module.exports = function (block, slug) {
   // Example to change a string to boolean
   // block.subtitle = !!(block.subtitle)
 

--- a/src/tasks/templates/migration-file.js
+++ b/src/tasks/templates/migration-file.js
@@ -1,4 +1,4 @@
-export default `export default function (block) {
+export default `export default function (block, slug) {
   // Example to change a string to boolean
   // block.{{ fieldname }} = !!(block.{{ fieldname }})
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

- Run `storyblok generate-migration`
- The generated migration file should include a second `slug` parameter

## What is the new behavior?

- Adds the currently-undocumented `slug` argument to the template generated by `generation-migration
- Updates the Readme accordingly

## Other information

The slug is already being passed into the migration function [here](https://github.com/storyblok/storyblok-cli/blob/master/src/tasks/migrations/utils.js#L201)
