### PR TITLE
fix: replace ofetch native fetch

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -82,6 +82,20 @@
       "env": {
         "STUB": "true"
       }
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Test",
+      "program": "${workspaceFolder}/dist/index.mjs",
+      "args": ["test"],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
+      "sourceMaps": true,
+      "outFiles": ["${workspaceFolder}/dist/**/*.js"],
+      "env": {
+        "STUB": "true"
+      }
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -30,6 +30,20 @@
     {
       "type": "node",
       "request": "launch",
+      "name": "Debug login by token",
+      "program": "${workspaceFolder}/dist/index.mjs",
+      "args": ["login", "--token", "1234567890"],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
+      "sourceMaps": true,
+      "outFiles": ["${workspaceFolder}/dist/**/*.js"],
+      "env": {
+        "STUB": "true"
+      }
+    },
+    {
+      "type": "node",
+      "request": "launch",
       "name": "Debug logout",
       "program": "${workspaceFolder}/dist/index.mjs",
       "args": ["logout"],

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "chalk": "^5.3.0",
     "commander": "^12.1.0",
     "dotenv": "^16.4.5",
-    "ofetch": "^1.4.0",
     "storyblok-js-client": "^6.9.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       dotenv:
         specifier: ^16.4.5
         version: 16.4.5
-      ofetch:
-        specifier: ^1.4.0
-        version: 1.4.0
       storyblok-js-client:
         specifier: ^6.9.2
         version: 6.9.2
@@ -1468,9 +1465,6 @@ packages:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
-  destr@2.0.3:
-    resolution: {integrity: sha512-2N3BOUU4gYMpTP24s5rF5iP7BDr7uNTCs4ozw3kf/eKfvWSIu93GEBi5m427YoyJoeOzQ5smuu4nNAPGb8idSQ==}
-
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
@@ -2336,9 +2330,6 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
-  node-fetch-native@1.6.4:
-    resolution: {integrity: sha512-IhOigYzAKHd244OC0JIMIUrjzctirCmPkaIfhDeGcEETWof5zKYUW7e7MYvChGWh/4CJeXEgsRyGzuF334rOOQ==}
-
   node-releases@2.0.18:
     resolution: {integrity: sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==}
 
@@ -2351,9 +2342,6 @@ packages:
 
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
-
-  ofetch@1.4.0:
-    resolution: {integrity: sha512-MuHgsEhU6zGeX+EMh+8mSMrYTnsqJQQrpM00Q6QHMKNqQ0bKy0B43tk8tL1wg+CnsSTy1kg4Ir2T5Ig6rD+dfQ==}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -4499,8 +4487,6 @@ snapshots:
 
   dequal@2.0.3: {}
 
-  destr@2.0.3: {}
-
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
@@ -5652,8 +5638,6 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  node-fetch-native@1.6.4: {}
-
   node-releases@2.0.18: {}
 
   normalize-package-data@2.5.0:
@@ -5668,12 +5652,6 @@ snapshots:
   nth-check@2.1.1:
     dependencies:
       boolbase: 1.0.0
-
-  ofetch@1.4.0:
-    dependencies:
-      destr: 2.0.3
-      node-fetch-native: 1.6.4
-      ufo: 1.5.4
 
   once@1.4.0:
     dependencies:

--- a/src/commands/login/actions.ts
+++ b/src/commands/login/actions.ts
@@ -1,12 +1,13 @@
 import chalk from 'chalk'
 import type { RegionCode } from '../../constants'
-import { regionsDomain } from '../../constants'
-import { FetchError, ofetch } from 'ofetch'
+import { customFetch, FetchError } from '../../utils/fetch'
 import { APIError, handleAPIError, maskToken } from '../../utils'
+import { getStoryblokUrl } from '../../utils/api-routes'
 
 export const loginWithToken = async (token: string, region: RegionCode) => {
   try {
-    return await ofetch(`https://${regionsDomain[region]}/v1/users/me`, {
+    const url = getStoryblokUrl(region)
+    return await customFetch(`${url}/users/me`, {
       headers: {
         Authorization: token,
       },
@@ -14,7 +15,7 @@ export const loginWithToken = async (token: string, region: RegionCode) => {
   }
   catch (error) {
     if (error instanceof FetchError) {
-      const status = error.response?.status
+      const status = error.response.status
 
       switch (status) {
         case 401:
@@ -24,17 +25,16 @@ export const loginWithToken = async (token: string, region: RegionCode) => {
           throw new APIError('network_error', 'login_with_token', error)
       }
     }
-    else {
-      throw new APIError('generic', 'login_with_token', error as Error)
-    }
+    throw new APIError('generic', 'login_with_token', error as FetchError)
   }
 }
 
 export const loginWithEmailAndPassword = async (email: string, password: string, region: RegionCode) => {
   try {
-    return await ofetch(`https://${regionsDomain[region]}/v1/users/login`, {
+    const url = getStoryblokUrl(region)
+    return await customFetch(`${url}/users/login`, {
       method: 'POST',
-      body: JSON.stringify({ email, password }),
+      body: { email, password },
     })
   }
   catch (error) {
@@ -44,9 +44,10 @@ export const loginWithEmailAndPassword = async (email: string, password: string,
 
 export const loginWithOtp = async (email: string, password: string, otp: string, region: RegionCode) => {
   try {
-    return await ofetch(`https://${regionsDomain[region]}/v1/users/login`, {
+    const url = getStoryblokUrl(region)
+    return await customFetch(`${url}/users/login`, {
       method: 'POST',
-      body: JSON.stringify({ email, password, otp_attempt: otp }),
+      body: { email, password, otp_attempt: otp },
     })
   }
   catch (error) {

--- a/src/commands/login/actions.ts
+++ b/src/commands/login/actions.ts
@@ -3,11 +3,14 @@ import type { RegionCode } from '../../constants'
 import { customFetch, FetchError } from '../../utils/fetch'
 import { APIError, handleAPIError, maskToken } from '../../utils'
 import { getStoryblokUrl } from '../../utils/api-routes'
+import type { StoryblokLoginResponse, StoryblokLoginWithOtpResponse, StoryblokUser } from '../../types'
 
 export const loginWithToken = async (token: string, region: RegionCode) => {
   try {
     const url = getStoryblokUrl(region)
-    return await customFetch(`${url}/users/me`, {
+    return await customFetch<{
+      user: StoryblokUser
+    }>(`${url}/users/me`, {
       headers: {
         Authorization: token,
       },
@@ -32,7 +35,7 @@ export const loginWithToken = async (token: string, region: RegionCode) => {
 export const loginWithEmailAndPassword = async (email: string, password: string, region: RegionCode) => {
   try {
     const url = getStoryblokUrl(region)
-    return await customFetch(`${url}/users/login`, {
+    return await customFetch<StoryblokLoginResponse>(`${url}/users/login`, {
       method: 'POST',
       body: { email, password },
     })
@@ -45,7 +48,7 @@ export const loginWithEmailAndPassword = async (email: string, password: string,
 export const loginWithOtp = async (email: string, password: string, otp: string, region: RegionCode) => {
   try {
     const url = getStoryblokUrl(region)
-    return await customFetch(`${url}/users/login`, {
+    return await customFetch<StoryblokLoginWithOtpResponse>(`${url}/users/login`, {
       method: 'POST',
       body: { email, password, otp_attempt: otp },
     })

--- a/src/commands/login/index.ts
+++ b/src/commands/login/index.ts
@@ -112,16 +112,18 @@ export const loginCommand = program
           })
           const response = await loginWithEmailAndPassword(userEmail, userPassword, userRegion)
 
-          if (response.otp_required) {
+          if (response?.otp_required) {
             const otp = await input({
               message: 'Add the code from your Authenticator app, or the one we sent to your e-mail / phone:',
               required: true,
             })
 
-            const { access_token } = await loginWithOtp(userEmail, userPassword, otp, userRegion)
-            updateSession(userEmail, access_token, userRegion)
+            const otpResponse = await loginWithOtp(userEmail, userPassword, otp, userRegion)
+            if (otpResponse?.access_token) {
+              updateSession(userEmail, otpResponse?.access_token, userRegion)
+            }
           }
-          else {
+          else if (response?.access_token) {
             updateSession(userEmail, response.access_token, userRegion)
           }
           await persistCredentials(regionsDomain[userRegion])

--- a/src/commands/pull-languages/actions.ts
+++ b/src/commands/pull-languages/actions.ts
@@ -11,7 +11,9 @@ import { getStoryblokUrl } from '../../utils/api-routes'
 export const pullLanguages = async (space: string, token: string, region: RegionCode): Promise<SpaceInternationalization | undefined> => {
   try {
     const url = getStoryblokUrl(region)
-    const response = await customFetch(`${url}/spaces/${space}`, {
+    const response = await customFetch<{
+      space: SpaceInternationalization
+    }>(`${url}/spaces/${space}`, {
       headers: {
         Authorization: token,
       },

--- a/src/commands/user/actions.ts
+++ b/src/commands/user/actions.ts
@@ -3,15 +3,19 @@ import type { RegionCode } from '../../constants'
 import { customFetch, FetchError } from '../../utils/fetch'
 import { APIError, maskToken } from '../../utils'
 import { getStoryblokUrl } from '../../utils/api-routes'
+import type { StoryblokUser } from '../../types'
 
 export const getUser = async (token: string, region: RegionCode) => {
   try {
     const url = getStoryblokUrl(region)
-    return await customFetch(`${url}/users/me`, {
+    const response = await customFetch<{
+      user: StoryblokUser
+    }>(`${url}/users/me`, {
       headers: {
         Authorization: token,
       },
     })
+    return response
   }
   catch (error) {
     if (error instanceof FetchError) {

--- a/src/commands/user/actions.ts
+++ b/src/commands/user/actions.ts
@@ -1,11 +1,13 @@
-import { FetchError, ofetch } from 'ofetch'
-import { regionsDomain } from '../../constants'
 import chalk from 'chalk'
+import type { RegionCode } from '../../constants'
+import { customFetch, FetchError } from '../../utils/fetch'
 import { APIError, maskToken } from '../../utils'
+import { getStoryblokUrl } from '../../utils/api-routes'
 
-export const getUser = async (token: string, region: string) => {
+export const getUser = async (token: string, region: RegionCode) => {
   try {
-    return await ofetch(`https://${regionsDomain[region]}/v1/users/me`, {
+    const url = getStoryblokUrl(region)
+    return await customFetch(`${url}/users/me`, {
       headers: {
         Authorization: token,
       },
@@ -13,7 +15,7 @@ export const getUser = async (token: string, region: string) => {
   }
   catch (error) {
     if (error instanceof FetchError) {
-      const status = error.response?.status
+      const status = error.response.status
 
       switch (status) {
         case 401:
@@ -23,8 +25,6 @@ export const getUser = async (token: string, region: string) => {
           throw new APIError('network_error', 'get_user', error)
       }
     }
-    else {
-      throw new APIError('generic', 'get_user', error as Error)
-    }
+    throw new APIError('generic', 'get_user', error as FetchError)
   }
 }

--- a/src/commands/user/index.ts
+++ b/src/commands/user/index.ts
@@ -23,6 +23,7 @@ export const userCommand = program
     try {
       const { password, region } = state as NetrcMachine
       const { user } = await getUser(password, region)
+      console.log(user)
       konsola.ok(`Hi ${chalk.bold(user.friendly_name)}, you are currently logged in with ${chalk.hex(colorPalette.PRIMARY)(user.email)} on ${chalk.bold(region)} region`)
     }
     catch (error) {

--- a/src/commands/user/index.ts
+++ b/src/commands/user/index.ts
@@ -23,7 +23,6 @@ export const userCommand = program
     try {
       const { password, region } = state as NetrcMachine
       const { user } = await getUser(password, region)
-      console.log(user)
       konsola.ok(`Hi ${chalk.bold(user.friendly_name)}, you are currently logged in with ${chalk.hex(colorPalette.PRIMARY)(user.email)} on ${chalk.bold(region)} region`)
     }
     catch (error) {

--- a/src/creds.ts
+++ b/src/creds.ts
@@ -3,11 +3,12 @@ import { join } from 'node:path'
 import { FileSystemError, handleFileSystemError, konsola } from './utils'
 import chalk from 'chalk'
 import { colorPalette, regionCodes } from './constants'
+import type { RegionCode } from './constants'
 
 export interface NetrcMachine {
   login: string
   password: string
-  region: string
+  region: RegionCode
 }
 
 export const getNetrcFilePath = () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,9 @@ import './commands/logout'
 import './commands/user'
 import './commands/pull-languages'
 
-import { loginWithToken } from './commands/login/actions'
+import { customFetch } from './utils/fetch'
+import { getStoryblokUrl } from './utils/api-routes'
+import { session } from './session'
 
 dotenv.config() // This will load variables from .env into process.env
 const program = getProgram()
@@ -31,8 +33,20 @@ program.command('test').action(async () => {
   konsola.title(`Test`, '#8556D3', 'Attempting a test...')
   const verbose = program.opts().verbose
   try {
-    // await loginWithEmailAndPassword('aw', 'passwrod', 'eu')
-    await loginWithToken('WYSYDHYASDHSYD', 'eu')
+    const { state, initializeSession } = session()
+    await initializeSession()
+    const url = getStoryblokUrl()
+
+    if (!state.password) {
+      throw new Error('No password found')
+    }
+
+    const response = await customFetch(`${url}/spaces/2950170505/components`, {
+      headers: {
+        Authorization: state.password,
+      },
+    })
+    console.log(response)
   }
   catch (error) {
     handleError(error as Error, verbose)

--- a/src/session.ts
+++ b/src/session.ts
@@ -6,7 +6,7 @@ interface SessionState {
   isLoggedIn: boolean
   login?: string
   password?: string
-  region?: string
+  region?: RegionCode
   envLogin?: boolean
 }
 
@@ -24,7 +24,7 @@ function createSession() {
       state.isLoggedIn = true
       state.login = envCredentials.login
       state.password = envCredentials.password
-      state.region = envCredentials.region
+      state.region = envCredentials.region as RegionCode
       state.envLogin = true
       return
     }
@@ -36,7 +36,7 @@ function createSession() {
       state.isLoggedIn = true
       state.login = creds.login
       state.password = creds.password
-      state.region = creds.region
+      state.region = creds.region as RegionCode
     }
     else {
       // No credentials found; set state to logged out

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -1,0 +1,10 @@
+/**
+ * Interface representing an HTTP response error
+ */
+export interface ResponseError extends Error {
+  response?: {
+    status: number
+    statusText: string
+    data?: any
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,6 +8,8 @@ export interface CommandOptions {
   verbose: boolean
 }
 
+// All these types should come from a general package
+
 /**
  * Interface representing a language in Storyblok
  */
@@ -21,4 +23,29 @@ export interface Language {
 export interface SpaceInternationalization {
   languages: Language[]
   default_lang_name: string
+}
+
+export interface StoryblokUser {
+  id: number
+  email: string
+  username: string
+  friendly_name: string
+  otp_required: boolean
+  access_token: string
+}
+
+export interface StoryblokLoginResponse {
+  otp_required: boolean
+  login_strategy: string
+  configured_2fa_options: string[]
+  access_token?: string
+}
+
+export interface StoryblokLoginWithOtpResponse {
+  access_token: string
+  email: string
+  token_type: string
+  user_id: number
+  role: string
+  has_partner: boolean
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,3 +7,18 @@ export interface CommandOptions {
    */
   verbose: boolean
 }
+
+/**
+ * Interface representing a language in Storyblok
+ */
+export interface Language {
+  name: string
+  code: string
+  fallback_code?: string
+  ai_translation_code: string | null
+}
+
+export interface SpaceInternationalization {
+  languages: Language[]
+  default_lang_name: string
+}

--- a/src/utils/api-routes.ts
+++ b/src/utils/api-routes.ts
@@ -1,0 +1,8 @@
+import type { RegionCode } from '../constants'
+import { regionsDomain } from '../constants'
+
+const API_VERSION = 'v1'
+
+export const getStoryblokUrl = (region: RegionCode) => {
+  return `https://${regionsDomain[region]}/${API_VERSION}`
+}

--- a/src/utils/api-routes.ts
+++ b/src/utils/api-routes.ts
@@ -3,6 +3,6 @@ import { regionsDomain } from '../constants'
 
 const API_VERSION = 'v1'
 
-export const getStoryblokUrl = (region: RegionCode) => {
+export const getStoryblokUrl = (region: RegionCode = 'eu') => {
   return `https://${regionsDomain[region]}/${API_VERSION}`
 }

--- a/src/utils/error/api-error.ts
+++ b/src/utils/error/api-error.ts
@@ -1,4 +1,4 @@
-import { FetchError } from 'ofetch'
+import { FetchError } from '../fetch'
 
 export const API_ACTIONS = {
   login: 'login',
@@ -18,9 +18,9 @@ export const API_ERRORS = {
   not_found: 'The requested resource was not found',
 } as const
 
-export function handleAPIError(action: keyof typeof API_ACTIONS, error: Error): void {
+export function handleAPIError(action: keyof typeof API_ACTIONS, error: unknown): void {
   if (error instanceof FetchError) {
-    const status = error.response?.status
+    const status = error.response.status
 
     switch (status) {
       case 401:
@@ -33,10 +33,7 @@ export function handleAPIError(action: keyof typeof API_ACTIONS, error: Error): 
         throw new APIError('network_error', action, error)
     }
   }
-  else if (error.message.includes('NetworkError') || error.message.includes('Failed to fetch')) {
-    throw new APIError('network_error', action, error)
-  }
-  throw new APIError('generic', action, error)
+  throw new APIError('generic', action, error as FetchError)
 }
 
 export class APIError extends Error {

--- a/src/utils/error/error.ts
+++ b/src/utils/error/error.ts
@@ -1,12 +1,13 @@
 import { konsola } from '..'
+import type { FetchError } from '../fetch'
 import { APIError } from './api-error'
 import { CommandError } from './command-error'
 import { FileSystemError } from './filesystem-error'
 
-export function handleError(error: Error, verbose = false): void {
+export function handleError(error: Error | FetchError, verbose = false): void {
   // Print the message stack if it exists
-  if ((error as any).messageStack) {
-    const messageStack = (error as any).messageStack
+  if (error instanceof APIError || error instanceof FileSystemError) {
+    const messageStack = (error).messageStack
     messageStack.forEach((message: string, index: number) => {
       konsola.error(message, null, {
         header: index === 0,
@@ -19,8 +20,8 @@ export function handleError(error: Error, verbose = false): void {
       header: true,
     })
   }
-  if (verbose && typeof (error as any).getInfo === 'function') {
-    const errorDetails = (error as any).getInfo()
+  if (verbose && (error instanceof APIError || error instanceof FileSystemError)) {
+    const errorDetails = error.getInfo()
     if (error instanceof CommandError) {
       konsola.error(`Command Error: ${error.getInfo().message}`, errorDetails)
     }
@@ -31,7 +32,7 @@ export function handleError(error: Error, verbose = false): void {
       konsola.error(`File System Error: ${error.getInfo().cause}`, errorDetails)
     }
     else {
-      konsola.error(`Unexpected Error: ${error.message}`, errorDetails)
+      konsola.error(`Unexpected Error: ${error}`, errorDetails)
     }
   }
   else {

--- a/src/utils/fetch.test.ts
+++ b/src/utils/fetch.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from 'vitest'
+import { customFetch, FetchError } from './fetch'
+
+// Mock fetch
+const mockFetch = vi.fn()
+globalThis.fetch = mockFetch
+
+describe('customFetch', () => {
+  it('should make a successful GET request', async () => {
+    const mockResponse = { data: 'test' }
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      headers: { get: () => 'application/json' },
+      json: () => Promise.resolve(mockResponse),
+    })
+
+    const result = await customFetch('https://api.test.com')
+    expect(result).toEqual(mockResponse)
+  })
+
+  it('should handle object body by stringifying it', async () => {
+    const body = { test: 'data' }
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      headers: { get: () => 'application/json' },
+      json: () => Promise.resolve({}),
+    })
+
+    await customFetch('https://api.test.com', { body })
+
+    expect(mockFetch).toHaveBeenCalledWith('https://api.test.com', expect.objectContaining({
+      body: JSON.stringify(body),
+    }))
+  })
+
+  it('should pass string body as-is without modification', async () => {
+    const body = '{"test":"data"}'
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      headers: { get: () => 'application/json' },
+      json: () => Promise.resolve({}),
+    })
+
+    await customFetch('https://api.test.com', { body })
+
+    expect(mockFetch).toHaveBeenCalledWith('https://api.test.com', expect.objectContaining({
+      body,
+    }))
+  })
+
+  it('should handle array body by stringifying it', async () => {
+    const body = ['test', 'data']
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      headers: { get: () => 'application/json' },
+      json: () => Promise.resolve({}),
+    })
+
+    await customFetch('https://api.test.com', { body })
+
+    expect(mockFetch).toHaveBeenCalledWith('https://api.test.com', expect.objectContaining({
+      body: JSON.stringify(body),
+    }))
+  })
+
+  it('should handle non-JSON responses', async () => {
+    const textResponse = 'Hello World'
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      headers: { get: () => 'text/plain' },
+      text: () => Promise.resolve(textResponse),
+    })
+
+    await expect(customFetch('https://api.test.com')).rejects.toThrow(FetchError)
+  })
+
+  it('should throw FetchError for HTTP errors', async () => {
+    const errorResponse = { message: 'Not Found' }
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      json: () => Promise.resolve(errorResponse),
+    })
+
+    await expect(customFetch('https://api.test.com')).rejects.toThrow(FetchError)
+    await expect(customFetch('https://api.test.com')).rejects.toMatchObject({
+      response: {
+        status: 404,
+        statusText: 'Not Found',
+        data: errorResponse,
+      },
+    })
+  })
+
+  it('should handle network errors', async () => {
+    mockFetch.mockRejectedValue(new Error('Network Error'))
+
+    await expect(customFetch('https://api.test.com')).rejects.toThrow(FetchError)
+    await expect(customFetch('https://api.test.com')).rejects.toMatchObject({
+      response: {
+        status: 0,
+        statusText: 'Network Error',
+        data: null,
+      },
+    })
+  })
+
+  it('should set correct headers', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      headers: { get: () => 'application/json' },
+      json: () => Promise.resolve({}),
+    })
+
+    await customFetch('https://api.test.com', {
+      headers: {
+        Authorization: 'Bearer token',
+      },
+    })
+
+    expect(mockFetch).toHaveBeenCalledWith('https://api.test.com', expect.objectContaining({
+      headers: expect.objectContaining({
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer token',
+      }),
+    }))
+  })
+})

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -1,0 +1,82 @@
+export class FetchError extends Error {
+  response: {
+    status: number
+    statusText: string
+    data?: any
+  }
+
+  constructor(message: string, response: { status: number, statusText: string, data?: any }) {
+    super(message)
+    this.name = 'FetchError'
+    this.response = response
+  }
+}
+
+type FetchOptions = Omit<RequestInit, 'body'> & {
+  body?: any
+}
+
+export async function customFetch<T = any>(url: string, options: FetchOptions = {}): Promise<T> {
+  try {
+    const headers = {
+      'Content-Type': 'application/json',
+      ...options.headers,
+    }
+
+    // Handle JSON body
+    const fetchOptions: RequestInit = {
+      ...options,
+      headers,
+    }
+
+    if (options.body) {
+      if (typeof options.body === 'string') {
+        try {
+          JSON.parse(options.body)
+          fetchOptions.body = options.body
+        }
+        catch {
+          fetchOptions.body = JSON.stringify(options.body)
+        }
+      }
+      else {
+        fetchOptions.body = JSON.stringify(options.body)
+      }
+    }
+
+    const response = await fetch(url, fetchOptions)
+
+    if (!response.ok) {
+      let data
+      try {
+        data = await response.json()
+      }
+      catch {
+        // Ignore JSON parse errors
+      }
+      throw new FetchError(`HTTP error! status: ${response.status}`, {
+        status: response.status,
+        statusText: response.statusText,
+        data,
+      })
+    }
+
+    // Handle empty responses
+    const contentType = response.headers.get('content-type')
+    if (contentType?.includes('application/json')) {
+      return await response.json()
+    }
+    return await response.text() as T
+  }
+  catch (error) {
+    if (error instanceof FetchError) {
+      throw error
+    }
+    // For network errors or other non-HTTP errors, create a FetchError
+    throw new FetchError(error instanceof Error ? error.message : String(error), {
+      status: 0,
+      statusText: 'Network Error',
+      data: null,
+    })
+  }
+}


### PR DESCRIPTION
- Removed the `ofetch` dependency from multiple files and replaced it with a `customFetch` utility for better error handling and flexibility.
- Updated API calls in login, pull languages, and user actions to use the new fetch method.
- Introduced a new ResponseError interface for improved error management.
- Added a getStoryblokUrl utility function to centralize URL construction based on region.
- Enhanced error handling in API error management to accommodate the new FetchError class.

## How to test this PR

Unit tests remained the same. They are all passing

## Other information
