### PR TITLE
feat: migrations generate cmd

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -208,6 +208,20 @@
       "env": {
         "STUB": "true"
       }
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Migrations generate non-existing component",
+      "program": "${workspaceFolder}/dist/index.mjs",
+      "args": ["migrations", "generate", "non-existing", "--space", "295017"],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
+      "sourceMaps": true,
+      "outFiles": ["${workspaceFolder}/dist/**/*.js"],
+      "env": {
+        "STUB": "true"
+      }
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -194,6 +194,20 @@
       "env": {
         "STUB": "true"
       }
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Migrations generate",
+      "program": "${workspaceFolder}/dist/index.mjs",
+      "args": ["migrations", "generate", "--space", "295017"],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
+      "sourceMaps": true,
+      "outFiles": ["${workspaceFolder}/dist/**/*.js"],
+      "env": {
+        "STUB": "true"
+      }
     }
   ]
 }

--- a/src/commands/components/push/index.test.ts
+++ b/src/commands/components/push/index.test.ts
@@ -420,23 +420,14 @@ describe('push', () => {
         region: 'eu',
       };
 
-      const handleComponentsSpy = vi.fn().mockImplementation((args) => {
-        console.log('handleComponents called with:', JSON.stringify(args, null, 2));
-        return Promise.resolve({ successful: [], failed: [] });
-      });
-
       vi.mocked(readComponentsFiles).mockResolvedValue(mockedSpaceData);
 
       // We need these mocks for the final expect handleComponents call
       vi.mocked(handleWhitelists).mockResolvedValue(mockedWhitelistResults);
       vi.mocked(handleTags).mockResolvedValue(mockedTagsResults);
       vi.mocked(handleComponentGroups).mockResolvedValue(mockedGroupsResults);
-      vi.mocked(handleComponents).mockImplementation(handleComponentsSpy);
 
       await componentsCommand.parseAsync(['node', 'test', 'push', '--space', '12345']);
-
-      console.log('handleComponents mock calls:', vi.mocked(handleComponents).mock.calls);
-      console.log('handleComponents mock results:', vi.mocked(handleComponents).mock.results);
 
       expect(handleWhitelists).toHaveBeenCalledWith('12345', 'valid-token', 'eu', mockedSpaceData);
 

--- a/src/commands/components/push/index.ts
+++ b/src/commands/components/push/index.ts
@@ -108,22 +108,6 @@ componentsCommand
         component => !whitelistResults.processedComponentNames.has(component.name),
       );
 
-      console.log('handleComponents', {
-        space,
-        password,
-        region,
-        spaceData: {
-          ...spaceData,
-          components: remainingComponents,
-        },
-        groupsUuidMap: new Map([...whitelistResults.groupsUuidMap, ...groupsResults.uuidMap]), // Merge both group maps
-        tagsIdMaps: new Map([...whitelistResults.tagsIdMap, ...tagsResults.idMap]), // Merge both tag maps
-        componentNameMap: whitelistResults.componentNameMap,
-        processedGroupUuids: whitelistResults.processedGroupUuids,
-        processedTagIds: whitelistResults.processedTagIds,
-        processedComponentNames: whitelistResults.processedComponentNames,
-      });
-
       const componentsResults = await handleComponents({
         space,
         password,

--- a/src/commands/migrations/command.ts
+++ b/src/commands/migrations/command.ts
@@ -1,0 +1,11 @@
+import { getProgram } from '../../program';
+
+const program = getProgram(); // Get the shared singleton instance
+
+// Components root command
+export const migrationsCommand = program
+  .command('migrations')
+  .alias('mig')
+  .description(`Manage your space's migrations`)
+  .option('-s, --space <space>', 'space ID')
+  .option('-p, --path <path>', 'path to save the file. Default is .storyblok/migrations');

--- a/src/commands/migrations/generate/README.md
+++ b/src/commands/migrations/generate/README.md
@@ -1,18 +1,18 @@
 # Migrations Generate Command
 
-The `storyblok migrations generate` command allows you to generate migration files for specific component fields. This is useful when you need to transform or update field values across your Storyblok content.
+The `storyblok migrations generate` command allows you to generate migration files for specific components. This is useful when you need to transform or update field values across your Storyblok content.
 
 ## Basic Usage
 
 ```bash
-# Generate a migration for a specific component field
-storyblok migrations generate my-component --field my-field --space 295017
+# Generate a migration for a specific component
+storyblok migrations generate my-component --space 295017
 
 # Generate a migration with a custom path
-storyblok migrations generate my-component --field my-field --space 295017 --path ./custom-path
+storyblok migrations generate my-component --space 295017 --path ./custom-path
 
 # Generate a migration with a custom suffix
-storyblok migrations generate my-component --field my-field --space 295017 --suffix staging
+storyblok migrations generate my-component --space 295017 --suffix staging
 ```
 
 ## Command Options
@@ -20,9 +20,8 @@ storyblok migrations generate my-component --field my-field --space 295017 --suf
 | Option | Alias | Description |
 |--------|-------|-------------|
 | `--space <spaceId>` | `-s` | (Required) The ID of the space to generate migrations for |
-| `--field <fieldName>` | `--fi` | (Required) The name of the field to migrate |
 | `--path <path>` | `-p` | Custom path to store the migration files (default: ".storyblok/migrations/{spaceId}") |
-| `--suffix <suffix>` | `--su` | Suffix to add to the file name (e.g. {component-name}-{field}.<suffix>.js) |
+| `--suffix <suffix>` | `--su` | Suffix to add to the file name (e.g. {component-name}.<suffix>.js) |
 | `--verbose` | `-v` | Show detailed logs and error messages |
 
 ## Output Structure
@@ -33,7 +32,7 @@ The command will create a migration file in the following structure:
 .storyblok/
 └── migrations/
     └── {spaceId}/
-        └── {component-name}-{field}.js
+        └── {component-name}.js
 ```
 
 If a suffix is provided, the file will be named:
@@ -41,7 +40,7 @@ If a suffix is provided, the file will be named:
 .storyblok/
 └── migrations/
     └── {spaceId}/
-        └── {component-name}-{field}.<suffix>.js
+        └── {component-name}.<suffix>.js
 ```
 
 ## Migration File Structure
@@ -63,7 +62,7 @@ export default function (block) {
 ### Generate a Basic Migration
 
 ```bash
-storyblok migrations generate hero --field title --space 295017
+storyblok migrations generate hero --space 295017
 ```
 
 This will create:
@@ -72,13 +71,13 @@ This will create:
 .storyblok/
 └── migrations/
     └── 295017/
-        └── hero-title.js
+        └── hero.js
 ```
 
 ### Generate with Custom Path
 
 ```bash
-storyblok migrations generate hero --field title --space 295017 --path ./migrations
+storyblok migrations generate hero --space 295017 --path ./migrations
 ```
 
 This will create:
@@ -86,13 +85,13 @@ This will create:
 ```markdown
 migrations/
 └── 295017/
-    └── hero-title.js
+    └── hero.js
 ```
 
 ### Generate with Custom Suffix
 
 ```bash
-storyblok migrations generate hero --field title --space 295017 --suffix staging
+storyblok migrations generate hero --space 295017 --suffix staging
 ```
 
 This will create:
@@ -101,7 +100,7 @@ This will create:
 .storyblok/
 └── migrations/
     └── 295017/
-        └── hero-title.staging.js
+        └── hero.staging.js
 ```
 
 ## Error Cases
@@ -109,7 +108,6 @@ This will create:
 The command will fail with helpful error messages in the following cases:
 
 - No component name provided
-- No field name provided
 - No space ID provided
 - User not logged in
 - Component not found in the space
@@ -118,10 +116,10 @@ The command will fail with helpful error messages in the following cases:
 ## Manual Testing Checklist
 
 1. Basic Generation
-   - [ ] Generate migration for a simple field
+   - [ ] Generate migration for a component
    - [ ] Verify file is created in the correct location
    - [ ] Check if generated file has correct structure
-   - [ ] Verify component and field names are correctly set
+   - [ ] Verify component name is correctly set
 
 2. Path Options
    - [ ] Test default path generation
@@ -131,7 +129,6 @@ The command will fail with helpful error messages in the following cases:
 
 3. Error Handling
    - [ ] Test without component name
-   - [ ] Test without field name
    - [ ] Test without space ID
    - [ ] Test with non-existent component
    - [ ] Test while not logged in
@@ -139,7 +136,6 @@ The command will fail with helpful error messages in the following cases:
 
 4. Special Cases
    - [ ] Test with complex component names
-   - [ ] Test with nested field paths
    - [ ] Test verbose mode output
    - [ ] Test with various suffix values
    - [ ] Verify file permissions are correct
@@ -148,7 +144,7 @@ The command will fail with helpful error messages in the following cases:
 
 1. **Naming Conventions**
    - Use clear, descriptive names for your migration files
-   - Follow a consistent pattern for field names
+   - Follow a consistent pattern for component names
    - Use meaningful suffixes (e.g., 'staging', 'prod', 'v1')
 
 2. **Migration Logic**

--- a/src/commands/migrations/generate/README.md
+++ b/src/commands/migrations/generate/README.md
@@ -10,6 +10,9 @@ storyblok migrations generate my-component --field my-field --space 295017
 
 # Generate a migration with a custom path
 storyblok migrations generate my-component --field my-field --space 295017 --path ./custom-path
+
+# Generate a migration with a custom suffix
+storyblok migrations generate my-component --field my-field --space 295017 --suffix staging
 ```
 
 ## Command Options
@@ -19,6 +22,7 @@ storyblok migrations generate my-component --field my-field --space 295017 --pat
 | `--space <spaceId>` | `-s` | (Required) The ID of the space to generate migrations for |
 | `--field <fieldName>` | `--fi` | (Required) The name of the field to migrate |
 | `--path <path>` | `-p` | Custom path to store the migration files (default: ".storyblok/migrations/{spaceId}") |
+| `--suffix <suffix>` | `--su` | Suffix to add to the file name (e.g. {component-name}-{field}.<suffix>.js) |
 | `--verbose` | `-v` | Show detailed logs and error messages |
 
 ## Output Structure
@@ -29,7 +33,15 @@ The command will create a migration file in the following structure:
 .storyblok/
 └── migrations/
     └── {spaceId}/
-        └── {component-name}-{field-name}.js
+        └── {component-name}-{field}.js
+```
+
+If a suffix is provided, the file will be named:
+```markdown
+.storyblok/
+└── migrations/
+    └── {spaceId}/
+        └── {component-name}-{field}.<suffix>.js
 ```
 
 ## Migration File Structure
@@ -37,17 +49,13 @@ The command will create a migration file in the following structure:
 Each generated migration file follows this structure:
 
 ```javascript
-module.exports = {
-  // The name of the component to migrate
-  component: 'component-name',
-  // The field that will be migrated
-  field: 'field-name',
-  // The migration function that will be applied to the field
-  migrate: (field) => {
-    // Your migration logic here
-    return field;
-  }
-};
+export default function (block) {
+  // Example to change a string to boolean
+  // block.fullname = !!(block.fullname)
+
+  // Example to transfer content from other field
+  // block.fullname = block.other_field
+}
 ```
 
 ## Examples
@@ -81,6 +89,21 @@ migrations/
     └── hero-title.js
 ```
 
+### Generate with Custom Suffix
+
+```bash
+storyblok migrations generate hero --field title --space 295017 --suffix staging
+```
+
+This will create:
+
+```markdown
+.storyblok/
+└── migrations/
+    └── 295017/
+        └── hero-title.staging.js
+```
+
 ## Error Cases
 
 The command will fail with helpful error messages in the following cases:
@@ -103,6 +126,7 @@ The command will fail with helpful error messages in the following cases:
 2. Path Options
    - [ ] Test default path generation
    - [ ] Test custom path generation
+   - [ ] Test custom suffix generation
    - [ ] Verify directory structure is maintained
 
 3. Error Handling
@@ -117,6 +141,7 @@ The command will fail with helpful error messages in the following cases:
    - [ ] Test with complex component names
    - [ ] Test with nested field paths
    - [ ] Test verbose mode output
+   - [ ] Test with various suffix values
    - [ ] Verify file permissions are correct
 
 ## Best Practices
@@ -124,6 +149,7 @@ The command will fail with helpful error messages in the following cases:
 1. **Naming Conventions**
    - Use clear, descriptive names for your migration files
    - Follow a consistent pattern for field names
+   - Use meaningful suffixes (e.g., 'staging', 'prod', 'v1')
 
 2. **Migration Logic**
    - Keep migrations atomic (one change per migration)
@@ -133,6 +159,7 @@ The command will fail with helpful error messages in the following cases:
 3. **Version Control**
    - Commit migration files to version control
    - Include clear documentation of what each migration does
+   - Use suffixes to differentiate between environments
 
 ## Related Commands
 

--- a/src/commands/migrations/generate/README.md
+++ b/src/commands/migrations/generate/README.md
@@ -1,0 +1,139 @@
+# Migrations Generate Command
+
+The `storyblok migrations generate` command allows you to generate migration files for specific component fields. This is useful when you need to transform or update field values across your Storyblok content.
+
+## Basic Usage
+
+```bash
+# Generate a migration for a specific component field
+storyblok migrations generate my-component --field my-field --space 295017
+
+# Generate a migration with a custom path
+storyblok migrations generate my-component --field my-field --space 295017 --path ./custom-path
+```
+
+## Command Options
+
+| Option | Alias | Description |
+|--------|-------|-------------|
+| `--space <spaceId>` | `-s` | (Required) The ID of the space to generate migrations for |
+| `--field <fieldName>` | `--fi` | (Required) The name of the field to migrate |
+| `--path <path>` | `-p` | Custom path to store the migration files (default: ".storyblok/migrations/{spaceId}") |
+| `--verbose` | `-v` | Show detailed logs and error messages |
+
+## Output Structure
+
+The command will create a migration file in the following structure:
+
+```markdown
+.storyblok/
+└── migrations/
+    └── {spaceId}/
+        └── {component-name}-{field-name}.js
+```
+
+## Migration File Structure
+
+Each generated migration file follows this structure:
+
+```javascript
+module.exports = {
+  // The name of the component to migrate
+  component: 'component-name',
+  // The field that will be migrated
+  field: 'field-name',
+  // The migration function that will be applied to the field
+  migrate: (field) => {
+    // Your migration logic here
+    return field;
+  }
+};
+```
+
+## Examples
+
+### Generate a Basic Migration
+
+```bash
+storyblok migrations generate hero --field title --space 295017
+```
+
+This will create:
+
+```markdown
+.storyblok/
+└── migrations/
+    └── 295017/
+        └── hero-title.js
+```
+
+### Generate with Custom Path
+
+```bash
+storyblok migrations generate hero --field title --space 295017 --path ./migrations
+```
+
+This will create:
+
+```markdown
+migrations/
+└── 295017/
+    └── hero-title.js
+```
+
+## Error Cases
+
+The command will fail with helpful error messages in the following cases:
+
+- No component name provided
+- No field name provided
+- No space ID provided
+- User not logged in
+- Component not found in the space
+- Invalid space ID
+
+## Manual Testing Checklist
+
+1. Basic Generation
+   - [ ] Generate migration for a simple field
+   - [ ] Verify file is created in the correct location
+   - [ ] Check if generated file has correct structure
+   - [ ] Verify component and field names are correctly set
+
+2. Path Options
+   - [ ] Test default path generation
+   - [ ] Test custom path generation
+   - [ ] Verify directory structure is maintained
+
+3. Error Handling
+   - [ ] Test without component name
+   - [ ] Test without field name
+   - [ ] Test without space ID
+   - [ ] Test with non-existent component
+   - [ ] Test while not logged in
+   - [ ] Verify error messages are clear and helpful
+
+4. Special Cases
+   - [ ] Test with complex component names
+   - [ ] Test with nested field paths
+   - [ ] Test verbose mode output
+   - [ ] Verify file permissions are correct
+
+## Best Practices
+
+1. **Naming Conventions**
+   - Use clear, descriptive names for your migration files
+   - Follow a consistent pattern for field names
+
+2. **Migration Logic**
+   - Keep migrations atomic (one change per migration)
+   - Always include validation in your migration logic
+   - Test migrations on a staging space first
+
+3. **Version Control**
+   - Commit migration files to version control
+   - Include clear documentation of what each migration does
+
+## Related Commands
+
+- `storyblok migrations run` - Apply generated migrations to your content

--- a/src/commands/migrations/generate/actions.test.ts
+++ b/src/commands/migrations/generate/actions.test.ts
@@ -39,7 +39,6 @@ describe('generateMigration', () => {
     internal_tags_list: [],
     internal_tag_ids: [],
   };
-  const mockField = 'fullname';
 
   beforeEach(() => {
     // Reset all mocks before each test
@@ -55,19 +54,24 @@ describe('generateMigration', () => {
   it('should generate migration file with correct template', async () => {
     // Arrange
     const expectedPath = join(process.cwd(), '.storyblok', `migrations/${mockSpace}`);
-    const expectedFilePath = join(expectedPath, `${mockComponent.name}-${mockField}.js`);
+    const expectedFilePath = join(expectedPath, `${mockComponent.name}.js`);
 
     const expectedTemplate = `export default function (block) {
   // Example to change a string to boolean
-  // block.${mockField} = !!(block.${mockField})
+  // block.field_name = !!(block.field_name)
 
   // Example to transfer content from other field
-  // block.${mockField} = block.other_field
+  // block.target_field = block.source_field
+
+  // Example to transform an array
+  // block.array_field = block.array_field.map(item => ({ ...item, new_prop: 'value' }))
+
+  return block;
 }
 `;
 
     // Act
-    await generateMigration(mockSpace, mockPath, mockComponent, mockField);
+    await generateMigration(mockSpace, mockPath, mockComponent);
 
     // Assert
     expect(saveToFile).toHaveBeenCalledWith(expectedFilePath, expectedTemplate);
@@ -77,10 +81,10 @@ describe('generateMigration', () => {
     // Arrange
     const customPath = '/custom/path';
     const expectedPath = resolve(process.cwd(), customPath, 'migrations', mockSpace);
-    const expectedFilePath = join(expectedPath, `${mockComponent.name}-${mockField}.js`);
+    const expectedFilePath = join(expectedPath, `${mockComponent.name}.js`);
 
     // Act
-    await generateMigration(mockSpace, customPath, mockComponent, mockField);
+    await generateMigration(mockSpace, customPath, mockComponent);
 
     // Assert
     expect(saveToFile).toHaveBeenCalledTimes(1);
@@ -96,7 +100,7 @@ describe('generateMigration', () => {
     vi.mocked(saveToFile).mockRejectedValueOnce(mockError);
 
     // Act
-    await generateMigration(mockSpace, mockPath, mockComponent, mockField);
+    await generateMigration(mockSpace, mockPath, mockComponent);
 
     // Assert
     expect(handleFileSystemError).toHaveBeenCalledWith('write', mockError);

--- a/src/commands/migrations/generate/actions.test.ts
+++ b/src/commands/migrations/generate/actions.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { generateMigration } from './actions';
+import { resolvePath, saveToFile } from '../../../utils/filesystem';
+import { join, resolve } from 'node:path';
+import { handleFileSystemError } from '../../../utils';
+import type { SpaceComponent } from '../../components';
+
+// Mock the filesystem utils
+vi.mock('../../../utils/filesystem', () => ({
+  saveToFile: vi.fn(),
+  resolvePath: vi.fn(),
+}));
+
+// Mock the error handler
+vi.mock('../../../utils', () => ({
+  handleFileSystemError: vi.fn(),
+}));
+
+describe('generateMigration', () => {
+  const mockSpace = '295017';
+  const mockPath = '';
+  const mockComponent: SpaceComponent = {
+    name: 'test_component',
+    display_name: 'Test Component',
+    created_at: '2024-01-01',
+    updated_at: '2024-01-01',
+    id: 1,
+    schema: {
+      fullname: {
+        type: 'text',
+        pos: 0,
+      },
+      email: {
+        type: 'text',
+        pos: 1,
+      },
+    },
+    color: null,
+    internal_tags_list: [],
+    internal_tag_ids: [],
+  };
+  const mockField = 'fullname';
+
+  beforeEach(() => {
+    // Reset all mocks before each test
+    vi.clearAllMocks();
+    // Mock implementation for resolvePath
+    vi.mocked(resolvePath).mockImplementation((_, path) => join(process.cwd(), '.storyblok', path));
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('should generate migration file with correct template', async () => {
+    // Arrange
+    const expectedPath = join(process.cwd(), '.storyblok', `migrations/${mockSpace}`);
+    const expectedFilePath = join(expectedPath, `${mockComponent.name}-${mockField}.js`);
+
+    const expectedTemplate = `export default function (block) {
+  // Example to change a string to boolean
+  // block.${mockField} = !!(block.${mockField})
+
+  // Example to transfer content from other field
+  // block.${mockField} = block.other_field
+}
+`;
+
+    // Act
+    await generateMigration(mockSpace, mockPath, mockComponent, mockField);
+
+    // Assert
+    expect(saveToFile).toHaveBeenCalledWith(expectedFilePath, expectedTemplate);
+  });
+
+  it('should use custom path when provided', async () => {
+    // Arrange
+    const customPath = '/custom/path';
+    const expectedPath = resolve(process.cwd(), customPath, 'migrations', mockSpace);
+    const expectedFilePath = join(expectedPath, `${mockComponent.name}-${mockField}.js`);
+
+    // Act
+    await generateMigration(mockSpace, customPath, mockComponent, mockField);
+
+    // Assert
+    expect(saveToFile).toHaveBeenCalledTimes(1);
+    expect(saveToFile).toHaveBeenCalledWith(
+      expectedFilePath,
+      expect.any(String),
+    );
+  });
+
+  it('should handle filesystem errors properly', async () => {
+    // Arrange
+    const mockError = new Error('Failed to write file');
+    vi.mocked(saveToFile).mockRejectedValueOnce(mockError);
+
+    // Act
+    await generateMigration(mockSpace, mockPath, mockComponent, mockField);
+
+    // Assert
+    expect(handleFileSystemError).toHaveBeenCalledWith('write', mockError);
+  });
+});

--- a/src/commands/migrations/generate/actions.ts
+++ b/src/commands/migrations/generate/actions.ts
@@ -1,29 +1,34 @@
 import { resolvePath, saveToFile } from '../../../utils/filesystem';
-import type { SpaceComponent } from '../../../commands/components';
+import type { SpaceComponent } from '../../components/constants';
 import { join, resolve } from 'node:path';
 import { handleFileSystemError } from '../../../utils';
 
-const getMigrationTemplate = (fieldName: string) => {
+const getMigrationTemplate = () => {
   return `export default function (block) {
   // Example to change a string to boolean
-  // block.${fieldName} = !!(block.${fieldName})
+  // block.field_name = !!(block.field_name)
 
   // Example to transfer content from other field
-  // block.${fieldName} = block.other_field
+  // block.target_field = block.source_field
+
+  // Example to transform an array
+  // block.array_field = block.array_field.map(item => ({ ...item, new_prop: 'value' }))
+
+  return block;
 }
 `;
 };
 
-export const generateMigration = async (space: string, path: string | undefined, component: SpaceComponent, field: string, suffix?: string) => {
+export const generateMigration = async (space: string, path: string | undefined, component: SpaceComponent, suffix?: string) => {
   const resolvedPath = path
     ? resolve(process.cwd(), path, 'migrations', space)
     : resolvePath(path, `migrations/${space}`);
 
-  const fileName = suffix ? `${component.name}-${field}.${suffix}.js` : `${component.name}-${field}.js`;
+  const fileName = suffix ? `${component.name}.${suffix}.js` : `${component.name}.js`;
   const migrationPath = join(resolvedPath, fileName);
 
   try {
-    await saveToFile(migrationPath, getMigrationTemplate(field));
+    await saveToFile(migrationPath, getMigrationTemplate());
   }
   catch (error) {
     handleFileSystemError('write', error as Error);

--- a/src/commands/migrations/generate/actions.ts
+++ b/src/commands/migrations/generate/actions.ts
@@ -14,12 +14,13 @@ const getMigrationTemplate = (fieldName: string) => {
 `;
 };
 
-export const generateMigration = async (space: string, path: string, component: SpaceComponent, field: string) => {
+export const generateMigration = async (space: string, path: string | undefined, component: SpaceComponent, field: string, suffix?: string) => {
   const resolvedPath = path
     ? resolve(process.cwd(), path, 'migrations', space)
     : resolvePath(path, `migrations/${space}`);
 
-  const migrationPath = join(resolvedPath, `${component.name}-${field}.js`);
+  const fileName = suffix ? `${component.name}-${field}.${suffix}.js` : `${component.name}-${field}.js`;
+  const migrationPath = join(resolvedPath, fileName);
 
   try {
     await saveToFile(migrationPath, getMigrationTemplate(field));

--- a/src/commands/migrations/generate/actions.ts
+++ b/src/commands/migrations/generate/actions.ts
@@ -1,0 +1,30 @@
+import { resolvePath, saveToFile } from '../../../utils/filesystem';
+import type { SpaceComponent } from '../../../commands/components';
+import { join, resolve } from 'node:path';
+import { handleFileSystemError } from '../../../utils';
+
+const getMigrationTemplate = (fieldName: string) => {
+  return `export default function (block) {
+  // Example to change a string to boolean
+  // block.${fieldName} = !!(block.${fieldName})
+
+  // Example to transfer content from other field
+  // block.${fieldName} = block.other_field
+}
+`;
+};
+
+export const generateMigration = async (space: string, path: string, component: SpaceComponent, field: string) => {
+  const resolvedPath = path
+    ? resolve(process.cwd(), path, 'migrations', space)
+    : resolvePath(path, `migrations/${space}`);
+
+  const migrationPath = join(resolvedPath, `${component.name}-${field}.js`);
+
+  try {
+    await saveToFile(migrationPath, getMigrationTemplate(field));
+  }
+  catch (error) {
+    handleFileSystemError('write', error as Error);
+  }
+};

--- a/src/commands/migrations/generate/constants.ts
+++ b/src/commands/migrations/generate/constants.ts
@@ -1,0 +1,5 @@
+import type { CommandOptions } from '../../../types';
+
+export interface MigrationsGenerateOptions extends CommandOptions {
+  field: string;
+}

--- a/src/commands/migrations/generate/constants.ts
+++ b/src/commands/migrations/generate/constants.ts
@@ -1,5 +1,6 @@
 import type { CommandOptions } from '../../../types';
 
 export interface MigrationsGenerateOptions extends CommandOptions {
-  field: string;
+  field?: string;
+  suffix?: string;
 }

--- a/src/commands/migrations/generate/index.test.ts
+++ b/src/commands/migrations/generate/index.test.ts
@@ -100,10 +100,10 @@ describe('migrations generate command', () => {
 
     vi.mocked(fetchComponent).mockResolvedValue(mockComponent);
 
-    await migrationsCommand.parseAsync(['node', 'test', 'generate', 'component-name', '--field', 'field1', '--space', '12345']);
+    await migrationsCommand.parseAsync(['node', 'test', 'generate', 'component-name', '--space', '12345']);
 
-    expect(generateMigration).toHaveBeenCalledWith('12345', undefined, mockComponent, 'field1', undefined);
-    expect(konsola.ok).toHaveBeenCalledWith('You can find the migration file in .storyblok/migrations/12345/component-name-field1.js');
+    expect(generateMigration).toHaveBeenCalledWith('12345', undefined, mockComponent, undefined);
+    expect(konsola.ok).toHaveBeenCalledWith('You can find the migration file in .storyblok/migrations/12345/component-name.js');
   });
 
   it('should generate a migration with a path', async () => {
@@ -133,10 +133,10 @@ describe('migrations generate command', () => {
 
     vi.mocked(fetchComponent).mockResolvedValue(mockComponent);
 
-    await migrationsCommand.parseAsync(['node', 'test', 'generate', 'component-name', '--field', 'field1', '--space', '12345', '--path', 'custom']);
+    await migrationsCommand.parseAsync(['node', 'test', 'generate', 'component-name', '--space', '12345', '--path', 'custom']);
 
-    expect(generateMigration).toHaveBeenCalledWith('12345', 'custom', mockComponent, 'field1', undefined);
-    expect(konsola.ok).toHaveBeenCalledWith('You can find the migration file in custom/migrations/12345/component-name-field1.js');
+    expect(generateMigration).toHaveBeenCalledWith('12345', 'custom', mockComponent, undefined);
+    expect(konsola.ok).toHaveBeenCalledWith('You can find the migration file in custom/migrations/12345/component-name.js');
   });
 
   it('should throw an error if the component is not found', async () => {
@@ -148,7 +148,7 @@ describe('migrations generate command', () => {
 
     vi.mocked(fetchComponent).mockResolvedValue(undefined);
 
-    await migrationsCommand.parseAsync(['node', 'test', 'generate', 'component-name', '--field', 'field1', '--space', '12345']);
+    await migrationsCommand.parseAsync(['node', 'test', 'generate', 'component-name', '--space', '12345']);
 
     const mockError = new CommandError('No component found with name "component-name"');
     expect(konsola.error).toHaveBeenCalledWith(mockError, false);
@@ -162,19 +162,7 @@ describe('migrations generate command', () => {
     };
 
     const mockError = new CommandError('Please provide the component name as argument --componentName YOUR_COMPONENT_NAME.');
-    await migrationsCommand.parseAsync(['node', 'test', 'generate', '--field', 'field1', '--space', '12345']);
-    expect(konsola.error).toHaveBeenCalledWith(mockError, false);
-  });
-
-  it('should throw an error if the field is not provided', async () => {
-    session().state = {
-      isLoggedIn: true,
-      password: 'valid-token',
-      region: 'eu',
-    };
-
-    const mockError = new CommandError('Please provide the field name as argument --field YOUR_FIELD_NAME.');
-    await migrationsCommand.parseAsync(['node', 'test', 'generate', 'component-name', '--space', '12345']);
+    await migrationsCommand.parseAsync(['node', 'test', 'generate', '--space', '12345']);
     expect(konsola.error).toHaveBeenCalledWith(mockError, false);
   });
 });

--- a/src/commands/migrations/generate/index.test.ts
+++ b/src/commands/migrations/generate/index.test.ts
@@ -1,0 +1,195 @@
+import { konsola } from '../../../utils';
+import { fetchComponent } from '../../../commands/components';
+import { generateMigration } from './actions';
+// Import the main components module first to ensure proper initialization
+import '../index';
+import { migrationsCommand } from '../command';
+
+// Mock dependencies
+vi.mock('../../../utils', async () => {
+  const actualUtils = await vi.importActual('../../../utils');
+  return {
+    ...actualUtils,
+    isVitestRunning: true,
+    konsola: {
+      ok: vi.fn(),
+      title: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      br: vi.fn(),
+    },
+    handleError: (error: unknown, header = false) => {
+      konsola.error(error as string, header);
+      // Optionally, prevent process.exit during tests
+    },
+  };
+});
+
+// Mock the session module
+vi.mock('../../../session', () => {
+  let _cache: Record<string, any> | null = null;
+  const session = () => {
+    if (!_cache) {
+      _cache = {
+        state: {
+          isLoggedIn: true,
+          password: 'mock-token',
+          region: 'eu',
+        },
+        updateSession: vi.fn(),
+        persistCredentials: vi.fn(),
+        initializeSession: vi.fn(),
+        logout: vi.fn(),
+      };
+    }
+    return _cache;
+  };
+
+  return {
+    session,
+  };
+});
+
+vi.mock('../../../commands/components', () => ({
+  fetchComponent: vi.fn(),
+}));
+
+vi.mock('./actions', () => ({
+  generateMigration: vi.fn(),
+}));
+
+vi.mock('../../../program', () => ({
+  getProgram: vi.fn(() => ({
+    opts: () => ({ verbose: false }),
+  })),
+}));
+
+describe('migrations generate command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fetchComponent).mockResolvedValue(mockComponent);
+    vi.mocked(generateMigration).mockResolvedValue(undefined);
+
+    // Reset the option values
+    migrationsCommand._optionValues = {};
+    migrationsCommand._optionValueSources = {};
+    for (const command of migrationsCommand.commands) {
+      command._optionValueSources = {};
+      command._optionValues = {};
+    }
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+/*   it('should throw error if component name is not provided', async () => {
+    // Act
+    await migrationsCommand.parseAsync(['node', 'test', 'generate']);
+
+    // Assert
+    expect(handleError).toHaveBeenCalledWith(
+      expect.any(CommandError),
+      false,
+    );
+    expect(fetchComponent).not.toHaveBeenCalled();
+    expect(generateMigration).not.toHaveBeenCalled();
+  });
+
+  it('should throw error if user is not logged in', async () => {
+    // Arrange
+    vi.mocked(session).mockReturnValueOnce({
+      state: {
+        isLoggedIn: false,
+        password: undefined,
+        region: undefined,
+      },
+      initializeSession: vi.fn(),
+      updateSession: vi.fn(),
+      persistCredentials: vi.fn(),
+      logout: vi.fn(),
+    });
+
+    // Act
+    await migrationsCommand.parseAsync(['node', 'test', 'generate', 'test-component', '--field', 'title']);
+
+    // Assert
+    expect(handleError).toHaveBeenCalledWith(
+      expect.any(CommandError),
+      false,
+    );
+    expect(fetchComponent).not.toHaveBeenCalled();
+    expect(generateMigration).not.toHaveBeenCalled();
+  });
+
+  it('should throw error if space is not provided', async () => {
+    // Arrange
+    migrationsCommand.opts = vi.fn().mockReturnValue({ space: undefined, path: '' });
+
+    // Act
+    await migrationsCommand.parseAsync(['node', 'test', 'generate', 'test-component', '--field', 'title']);
+
+    // Assert
+    expect(handleError).toHaveBeenCalledWith(
+      expect.any(CommandError),
+      false,
+    );
+    expect(fetchComponent).not.toHaveBeenCalled();
+    expect(generateMigration).not.toHaveBeenCalled();
+  });
+
+  it('should throw error if component is not found', async () => {
+    // Arrange
+    vi.mocked(fetchComponent).mockResolvedValue(undefined);
+
+    // Act
+    await migrationsCommand.parseAsync(['node', 'test', 'generate', 'non-existent-component', '--field', 'title']);
+
+    // Assert
+    expect(handleError).toHaveBeenCalledWith(
+      expect.any(CommandError),
+      false,
+    );
+    expect(fetchComponent).toHaveBeenCalledWith(
+      '123456',
+      'non-existent-component',
+      'mock-token',
+      'eu',
+    );
+    expect(generateMigration).not.toHaveBeenCalled();
+  });
+
+  it('should generate migration file successfully', async () => {
+    // Act
+    await migrationsCommand.parseAsync(['node', 'test', 'generate', 'test-component', '--field', 'title']);
+
+    // Assert
+    expect(fetchComponent).toHaveBeenCalledWith(
+      '123456',
+      'test-component',
+      'mock-token',
+      'eu',
+    );
+    expect(generateMigration).toHaveBeenCalledWith(
+      '123456',
+      '',
+      mockComponent,
+      'title',
+    );
+    expect(konsola.ok).toHaveBeenCalled();
+    expect(handleError).not.toHaveBeenCalled();
+  });
+
+  it('should handle errors during execution', async () => {
+    // Arrange
+    const mockError = new Error('Something went wrong');
+    vi.mocked(fetchComponent).mockRejectedValue(mockError);
+
+    // Act
+    await migrationsCommand.parseAsync(['node', 'test', 'generate', 'test-component', '--field', 'title']);
+
+    // Assert
+    expect(handleError).toHaveBeenCalledWith(mockError, false);
+    expect(generateMigration).not.toHaveBeenCalled();
+  }); */
+});

--- a/src/commands/migrations/generate/index.test.ts
+++ b/src/commands/migrations/generate/index.test.ts
@@ -161,7 +161,7 @@ describe('migrations generate command', () => {
       region: 'eu',
     };
 
-    const mockError = new CommandError('Please provide the component name as argument --componentName YOUR_COMPONENT_NAME.');
+    const mockError = new CommandError('Please provide the component name as argument storyblok migrations generate YOUR_COMPONENT_NAME.');
     await migrationsCommand.parseAsync(['node', 'test', 'generate', '--space', '12345']);
     expect(konsola.error).toHaveBeenCalledWith(mockError, false);
   });

--- a/src/commands/migrations/generate/index.test.ts
+++ b/src/commands/migrations/generate/index.test.ts
@@ -102,7 +102,7 @@ describe('migrations generate command', () => {
 
     await migrationsCommand.parseAsync(['node', 'test', 'generate', 'component-name', '--field', 'field1', '--space', '12345']);
 
-    expect(generateMigration).toHaveBeenCalledWith('12345', undefined, mockComponent, 'field1');
+    expect(generateMigration).toHaveBeenCalledWith('12345', undefined, mockComponent, 'field1', undefined);
     expect(konsola.ok).toHaveBeenCalledWith('You can find the migration file in .storyblok/migrations/12345/component-name-field1.js');
   });
 
@@ -135,7 +135,7 @@ describe('migrations generate command', () => {
 
     await migrationsCommand.parseAsync(['node', 'test', 'generate', 'component-name', '--field', 'field1', '--space', '12345', '--path', 'custom']);
 
-    expect(generateMigration).toHaveBeenCalledWith('12345', 'custom', mockComponent, 'field1');
+    expect(generateMigration).toHaveBeenCalledWith('12345', 'custom', mockComponent, 'field1', undefined);
     expect(konsola.ok).toHaveBeenCalledWith('You can find the migration file in custom/migrations/12345/component-name-field1.js');
   });
 

--- a/src/commands/migrations/generate/index.ts
+++ b/src/commands/migrations/generate/index.ts
@@ -3,12 +3,12 @@ import chalk from 'chalk';
 
 import type { MigrationsGenerateOptions } from './constants';
 import { colorPalette, commands } from '../../../constants';
+import { getProgram } from '../../../program';
 import { CommandError, handleError, isVitest, konsola } from '../../../utils';
 import { session } from '../../../session';
-import { migrationsCommand } from '../command';
 import { fetchComponent } from '../../../commands/components';
+import { migrationsCommand } from '../command';
 import { generateMigration } from './actions';
-import { getProgram } from '../../../program';
 
 const program = getProgram();
 

--- a/src/commands/migrations/generate/index.ts
+++ b/src/commands/migrations/generate/index.ts
@@ -31,6 +31,11 @@ migrationsCommand
       return;
     }
 
+    if (!field) {
+      handleError(new CommandError(`Please provide the field name as argument --field YOUR_FIELD_NAME.`), verbose);
+      return;
+    }
+
     const { state, initializeSession } = session();
     await initializeSession();
 

--- a/src/commands/migrations/generate/index.ts
+++ b/src/commands/migrations/generate/index.ts
@@ -1,0 +1,72 @@
+import { Spinner } from '@topcli/spinner';
+import chalk from 'chalk';
+
+import type { MigrationsGenerateOptions } from './constants';
+import { colorPalette, commands } from '../../../constants';
+import { CommandError, handleError, isVitest, konsola } from '../../../utils';
+import { session } from '../../../session';
+import { migrationsCommand } from '../command';
+import { fetchComponent } from '../../../commands/components';
+import { generateMigration } from './actions';
+import { getProgram } from '../../../program';
+
+const program = getProgram();
+
+migrationsCommand
+  .command('generate [componentName]')
+  .description('Generate a migration file')
+  .option('--fi, --field <field>', 'field to migrate')
+  .action(async (componentName: string | undefined, options: MigrationsGenerateOptions) => {
+    konsola.title(` ${commands.MIGRATIONS} `, colorPalette.MIGRATIONS, componentName ? `Generating migration for component ${componentName}...` : 'Generating migrations...');
+    // Global options
+    const verbose = program.opts().verbose;
+
+    // Command options
+    const { space, path } = migrationsCommand.opts();
+
+    const { field } = options;
+
+    if (!componentName) {
+      handleError(new CommandError(`Please provide the component name as argument --componentName YOUR_COMPONENT_NAME.`), verbose);
+      return;
+    }
+
+    const { state, initializeSession } = session();
+    await initializeSession();
+
+    if (!state.isLoggedIn || !state.password || !state.region) {
+      handleError(new CommandError(`You are currently not logged in. Please login first to get your user info.`), verbose);
+      return;
+    }
+    if (!space) {
+      handleError(new CommandError(`Please provide the space as argument --space YOUR_SPACE_ID.`), verbose);
+      return;
+    }
+
+    const { password, region } = state;
+
+    try {
+      const spinner = new Spinner({
+        verbose: !isVitest,
+      }).start(`Generating migration for component ${componentName}...`);
+
+      if (componentName && field) {
+        const component = await fetchComponent(space, componentName, password, region);
+
+        if (!component) {
+          handleError(new CommandError(`No component found with name "${componentName}"`), verbose);
+          return;
+        }
+
+        await generateMigration(space, path, component, field);
+
+        spinner.succeed(`Migration generated for component ${chalk.hex(colorPalette.MIGRATIONS)(componentName)} and field ${chalk.hex(colorPalette.MIGRATIONS)(field)} - Completed in ${spinner.elapsedTime.toFixed(2)}ms`);
+
+        const migrationPath = path ? `${path}/migrations/${space}/${component.name}-${field}.js` : `.storyblok/migrations/${space}/${component.name}-${field}.js`;
+        konsola.ok(`You can find the migration file in ${chalk.hex(colorPalette.MIGRATIONS)(migrationPath)}`);
+      }
+    }
+    catch (error) {
+      handleError(error as Error, verbose);
+    }
+  });

--- a/src/commands/migrations/generate/index.ts
+++ b/src/commands/migrations/generate/index.ts
@@ -27,7 +27,7 @@ migrationsCommand
     const { suffix } = options;
 
     if (!componentName) {
-      handleError(new CommandError(`Please provide the component name as argument --componentName YOUR_COMPONENT_NAME.`), verbose);
+      handleError(new CommandError(`Please provide the component name as argument ${chalk.hex(colorPalette.MIGRATIONS)('storyblok migrations generate YOUR_COMPONENT_NAME.')}`), verbose);
       return;
     }
 
@@ -45,14 +45,14 @@ migrationsCommand
 
     const { password, region } = state;
 
+    const spinner = new Spinner({
+      verbose: !isVitest,
+    }).start(`Generating migration for component ${componentName}...`);
     try {
-      const spinner = new Spinner({
-        verbose: !isVitest,
-      }).start(`Generating migration for component ${componentName}...`);
-
       const component = await fetchComponent(space, componentName, password, region);
 
       if (!component) {
+        spinner.failed(`Failed to fetch component ${componentName}. Make sure the component exists in your space.`);
         handleError(new CommandError(`No component found with name "${componentName}"`), verbose);
         return;
       }
@@ -66,6 +66,7 @@ migrationsCommand
       konsola.ok(`You can find the migration file in ${chalk.hex(colorPalette.MIGRATIONS)(migrationPath)}`);
     }
     catch (error) {
+      spinner.failed(`Failed to generate migration for component ${componentName}`);
       handleError(error as Error, verbose);
     }
   });

--- a/src/commands/migrations/generate/index.ts
+++ b/src/commands/migrations/generate/index.ts
@@ -15,8 +15,7 @@ const program = getProgram();
 migrationsCommand
   .command('generate [componentName]')
   .description('Generate a migration file')
-  .option('--fi, --field <field>', 'field to migrate')
-  .option('--su, --suffix <suffix>', 'suffix to add to the file name (e.g. {component-name}-{field}.<suffix>.js)')
+  .option('--su, --suffix <suffix>', 'suffix to add to the file name (e.g. {component-name}.<suffix>.js)')
   .action(async (componentName: string | undefined, options: MigrationsGenerateOptions) => {
     konsola.title(` ${commands.MIGRATIONS} `, colorPalette.MIGRATIONS, componentName ? `Generating migration for component ${componentName}...` : 'Generating migrations...');
     // Global options
@@ -25,15 +24,10 @@ migrationsCommand
     // Command options
     const { space, path } = migrationsCommand.opts();
 
-    const { field, suffix } = options;
+    const { suffix } = options;
 
     if (!componentName) {
       handleError(new CommandError(`Please provide the component name as argument --componentName YOUR_COMPONENT_NAME.`), verbose);
-      return;
-    }
-
-    if (!field) {
-      handleError(new CommandError(`Please provide the field name as argument --field YOUR_FIELD_NAME.`), verbose);
       return;
     }
 
@@ -56,22 +50,20 @@ migrationsCommand
         verbose: !isVitest,
       }).start(`Generating migration for component ${componentName}...`);
 
-      if (componentName && field) {
-        const component = await fetchComponent(space, componentName, password, region);
+      const component = await fetchComponent(space, componentName, password, region);
 
-        if (!component) {
-          handleError(new CommandError(`No component found with name "${componentName}"`), verbose);
-          return;
-        }
-
-        await generateMigration(space, path, component, field, suffix);
-
-        spinner.succeed(`Migration generated for component ${chalk.hex(colorPalette.MIGRATIONS)(componentName)} and field ${chalk.hex(colorPalette.MIGRATIONS)(field)} - Completed in ${spinner.elapsedTime.toFixed(2)}ms`);
-
-        const fileName = suffix ? `${component.name}-${field}.${suffix}.js` : `${component.name}-${field}.js`;
-        const migrationPath = path ? `${path}/migrations/${space}/${fileName}` : `.storyblok/migrations/${space}/${fileName}`;
-        konsola.ok(`You can find the migration file in ${chalk.hex(colorPalette.MIGRATIONS)(migrationPath)}`);
+      if (!component) {
+        handleError(new CommandError(`No component found with name "${componentName}"`), verbose);
+        return;
       }
+
+      await generateMigration(space, path, component, suffix);
+
+      spinner.succeed(`Migration generated for component ${chalk.hex(colorPalette.MIGRATIONS)(componentName)} - Completed in ${spinner.elapsedTime.toFixed(2)}ms`);
+
+      const fileName = suffix ? `${component.name}.${suffix}.js` : `${component.name}.js`;
+      const migrationPath = path ? `${path}/migrations/${space}/${fileName}` : `.storyblok/migrations/${space}/${fileName}`;
+      konsola.ok(`You can find the migration file in ${chalk.hex(colorPalette.MIGRATIONS)(migrationPath)}`);
     }
     catch (error) {
       handleError(error as Error, verbose);

--- a/src/commands/migrations/generate/index.ts
+++ b/src/commands/migrations/generate/index.ts
@@ -16,6 +16,7 @@ migrationsCommand
   .command('generate [componentName]')
   .description('Generate a migration file')
   .option('--fi, --field <field>', 'field to migrate')
+  .option('--su, --suffix <suffix>', 'suffix to add to the file name (e.g. {component-name}-{field}.<suffix>.js)')
   .action(async (componentName: string | undefined, options: MigrationsGenerateOptions) => {
     konsola.title(` ${commands.MIGRATIONS} `, colorPalette.MIGRATIONS, componentName ? `Generating migration for component ${componentName}...` : 'Generating migrations...');
     // Global options
@@ -24,7 +25,7 @@ migrationsCommand
     // Command options
     const { space, path } = migrationsCommand.opts();
 
-    const { field } = options;
+    const { field, suffix } = options;
 
     if (!componentName) {
       handleError(new CommandError(`Please provide the component name as argument --componentName YOUR_COMPONENT_NAME.`), verbose);
@@ -63,11 +64,12 @@ migrationsCommand
           return;
         }
 
-        await generateMigration(space, path, component, field);
+        await generateMigration(space, path, component, field, suffix);
 
         spinner.succeed(`Migration generated for component ${chalk.hex(colorPalette.MIGRATIONS)(componentName)} and field ${chalk.hex(colorPalette.MIGRATIONS)(field)} - Completed in ${spinner.elapsedTime.toFixed(2)}ms`);
 
-        const migrationPath = path ? `${path}/migrations/${space}/${component.name}-${field}.js` : `.storyblok/migrations/${space}/${component.name}-${field}.js`;
+        const fileName = suffix ? `${component.name}-${field}.${suffix}.js` : `${component.name}-${field}.js`;
+        const migrationPath = path ? `${path}/migrations/${space}/${fileName}` : `.storyblok/migrations/${space}/${fileName}`;
         konsola.ok(`You can find the migration file in ${chalk.hex(colorPalette.MIGRATIONS)(migrationPath)}`);
       }
     }

--- a/src/commands/migrations/index.ts
+++ b/src/commands/migrations/index.ts
@@ -1,0 +1,5 @@
+import './command';
+import './generate';
+
+export * from './generate/actions';
+export * from './generate/constants';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,6 +4,7 @@ export const commands = {
   USER: 'user',
   COMPONENTS: 'Components',
   LANGUAGES: 'languages',
+  MIGRATIONS: 'Migrations',
 } as const;
 
 export const colorPalette = {
@@ -12,6 +13,7 @@ export const colorPalette = {
   USER: '#8BC34A',
   COMPONENTS: '#a185ff',
   LANGUAGES: '#FFC107',
+  MIGRATIONS: '#8CE2FF',
 } as const;
 
 export interface ReadonlyArray<T> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import './commands/logout';
 import './commands/user';
 import './commands/components';
 import './commands/languages';
+import './commands/migrations';
 
 import { session } from './session';
 


### PR DESCRIPTION

# Migrations Generate Command

The `storyblok migrations generate` command allows you to generate migration files for specific component fields. This is useful when you need to transform or update field values across your Storyblok content.

## Basic Usage

```bash
# Generate a migration for a specific component 
storyblok migrations generate my-component --space 295017

# Generate a migration with a custom path
storyblok migrations generate my-component --space 295017 --path ./custom-path

# Generate a migration with a custom suffix
storyblok migrations generate my-component --space 295017 --suffix fieldname
```

## Command Options

| Option | Alias | Description |
|--------|-------|-------------|
| `--space <spaceId>` | `-s` | (Required) The ID of the space to generate migrations for |
| `--path <path>` | `-p` | Custom path to store the migration files (default: ".storyblok/migrations/{spaceId}") |
| `--suffix <suffix>` | `--su` | Suffix to add to the file name (e.g. {component-name}-{field}.<suffix>.js) |
| `--verbose` | `-v` | Show detailed logs and error messages |

## Output Structure

The command will create a migration file in the following structure:

```markdown
.storyblok/
└── migrations/
    └── {spaceId}/
        └── {component-name}.js
```

If a suffix is provided, the file will be named:
```markdown
.storyblok/
└── migrations/
    └── {spaceId}/
        └── {component-name}.<suffix>.js
```

## Migration File Structure

Each generated migration file follows this structure:

```javascript
export default function (block) {
  // Example to change a string to boolean
  // block.fullname = !!(block.fullname)

  // Example to transfer content from other field
  // block.fullname = block.other_field
}
```

## Examples

### Generate a Basic Migration

```bash
storyblok migrations generate hero --space 295017
```

This will create:

```markdown
.storyblok/
└── migrations/
    └── 295017/
        └── hero.js
```

### Generate with Custom Path

```bash
storyblok migrations generate hero --space 295017 --path ./migrations
```

This will create:

```markdown
migrations/
└── 295017/
    └── hero.js
```

### Generate with Custom Suffix

```bash
storyblok migrations generate hero --space 295017 --suffix staging
```

This will create:

```markdown
.storyblok/
└── migrations/
    └── 295017/
        └── hero.staging.js
```

## Error Cases

The command will fail with helpful error messages in the following cases:

- No component name provided
- No field name provided
- No space ID provided
- User not logged in
- Component not found in the space
- Invalid space ID

## Manual Testing Checklist

1. Basic Generation
   - [x] Generate migration for a simple component
   - [x] Verify file is created in the correct location
   - [x] Check if generated file has correct structure
   - [x] Verify component and field names are correctly set

2. Path Options
   - [x] Test default path generation
   - [x] Test custom path generation
   - [x] Test custom suffix generation
   - [x] Verify directory structure is maintained

3. Error Handling
   - [ ] Test without component name
   - [x] Test without space ID
   - [ ] Test with non-existent component
   - [ ] Test while not logged in
   - [ ] Verify error messages are clear and helpful

4. Special Cases
   - [x] Test with complex component names
   - [ ] Test with nested field paths
   - [x] Test verbose mode output
   - [x] Test with various suffix values
   - [x] Verify file permissions are correct

## Best Practices

1. **Naming Conventions**
   - Use clear, descriptive names for your migration files
   - Follow a consistent pattern for field names
   - Use meaningful suffixes (e.g., 'staging', 'prod', 'v1')

2. **Migration Logic**
   - Keep migrations atomic (one change per migration)
   - Always include validation in your migration logic
   - Test migrations on a staging space first

3. **Version Control**
   - Commit migration files to version control
   - Include clear documentation of what each migration does
   - Use suffixes to differentiate between environments

## Related Commands

- `storyblok migrations run` - Apply generated migrations to your content
