### PR TITLE
fix: adds startsWith logic to sync for folders

### DIFF
--- a/src/tasks/sync.js
+++ b/src/tasks/sync.js
@@ -149,7 +149,10 @@ const SyncSpaces = {
     for (const folder of sourceFolders) {
       try {
         const folderResult = await this.client.get(`spaces/${this.sourceSpaceId}/stories/${folder.id}`)
-        const { data } = await this.client.get(`spaces/${this.targetSpaceId}/stories`, { with_slug: folder.full_slug })
+        const { data } = await this.client.get(`spaces/${this.targetSpaceId}/stories`, {
+            with_slug: folder.full_slug,
+            ...(this.startsWith ? { starts_with: this.startsWith } : {}),
+        })
         const existingFolder = data.stories[0] || null
         const folderData = await this.getStoryWithTranslatedSlugs(folderResult.data.story, existingFolder)
         delete folderData.id
@@ -236,7 +239,7 @@ const SyncSpaces = {
       componentsGroups: this.componentsGroups,
       componentsFullSync: this.componentsFullSync
     })
-    
+
     try {
       await syncComponentsInstance.sync()
     } catch (e) {

--- a/src/tasks/sync.js
+++ b/src/tasks/sync.js
@@ -140,19 +140,31 @@ const SyncSpaces = {
   async syncFolders () {
     console.log(chalk.green('✓') + ' Syncing folders...')
 
-    const sourceFolders = await this.client.getAll(`spaces/${this.sourceSpaceId}/stories`, {
+    const sourceFolderParams = {
       folder_only: 1,
       sort_by: 'slug:asc'
-    })
+    };
+
+    if (this.startsWith) {
+      sourceFolderParams.starts_with = this.startsWith;
+    }
+
+    const sourceFolders = await this.client.getAll(`spaces/${this.sourceSpaceId}/stories`, sourceFolderParams)
     const syncedFolders = {}
 
     for (const folder of sourceFolders) {
       try {
+
+        const targetFolderParams = {
+          with_slug: folder.full_slug,
+        };
+
+        if (this.startsWith) {
+          targetFolderParams.starts_with = this.startsWith;
+        }
+
         const folderResult = await this.client.get(`spaces/${this.sourceSpaceId}/stories/${folder.id}`)
-        const { data } = await this.client.get(`spaces/${this.targetSpaceId}/stories`, {
-            with_slug: folder.full_slug,
-            ...(this.startsWith ? { starts_with: this.startsWith } : {}),
-        })
+        const { data } = await this.client.get(`spaces/${this.targetSpaceId}/stories`, targetFolderParams)
         const existingFolder = data.stories[0] || null
         const folderData = await this.getStoryWithTranslatedSlugs(folderResult.data.story, existingFolder)
         delete folderData.id


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

Run the CLI sync command with the `--starts-with <path>` option and `--type folders`.
Now the CLI will only attempt to sync folders that exist within the `--start-with` path.

## What is the new behavior?

Allows the CLI to sync folders scoped to a specific folder path

## Other information

This copies the exact code used for Stories