### PR TITLE
fix: component presets filename should be pluralized

### DIFF
--- a/src/commands/components/pull/actions.ts
+++ b/src/commands/components/pull/actions.ts
@@ -119,7 +119,7 @@ export const saveComponentsToFiles = async (
         // Find and save associated presets
         const componentPresets = presets.filter(preset => preset.component_id === component.id);
         if (componentPresets.length > 0) {
-          const presetsFilePath = join(resolvedPath, suffix ? `${component.name}.preset.${suffix}.json` : `${component.name}.preset.json`);
+          const presetsFilePath = join(resolvedPath, suffix ? `${component.name}.presets.${suffix}.json` : `${component.name}.presets.json`);
           await saveToFile(presetsFilePath, JSON.stringify(componentPresets, null, 2));
         }
         // Always save groups in a consolidated file

--- a/src/commands/components/push/actions.test.ts
+++ b/src/commands/components/push/actions.test.ts
@@ -242,7 +242,7 @@ describe('push components actions', () => {
     it('should read components from separate files successfully', async () => {
       vol.fromJSON({
         '/path/to/components/23746/component-name.json': JSON.stringify(mockComponent),
-        '/path/to/components/23746/component-name.preset.json': JSON.stringify([mockComponentPreset]),
+        '/path/to/components/23746/component-name.presets.json': JSON.stringify([mockComponentPreset]),
         '/path/to/components/23746/groups.json': JSON.stringify([mockComponentGroup]),
         '/path/to/components/23746/tags.json': JSON.stringify([mockInternalTag]),
       });

--- a/src/commands/components/push/actions.ts
+++ b/src/commands/components/push/actions.ts
@@ -319,7 +319,7 @@ async function readSeparateFiles(resolvedPath: string): Promise<SpaceData> {
       }
       internalTags = result.data;
     }
-    else if (file.endsWith('.preset.json')) {
+    else if (file.endsWith('.presets.json')) {
       const result = await readJsonFile<SpaceComponentPreset>(filePath);
       if (result.error) {
         handleFileSystemError('read', result.error);


### PR DESCRIPTION
I was playing around with the beta when I noticed that the filename for component presets in the documentation doesn't match reality. The [documentation says `hero.presets.json`](https://github.com/storyblok/storyblok-cli/blob/dbcbbea41d8a2912627ee9227face42f7bad171a/src/commands/components/pull/README.md?plain=1#L128), the code creates `hero.preset.json`. Since the file holds data about multiple presets, I am assuming the documentation is correct so I'm changing the code to use `hero.presets.json`.