### PR TITLE
fix: add suffix support for component reading and pushing

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -198,6 +198,34 @@
     {
       "type": "node",
       "request": "launch",
+      "name": "Debug Push component with suffix",
+      "program": "${workspaceFolder}/dist/index.mjs",
+      "args": ["components", "push", "--space", "295018", "--from", "295017", "--suffix", "prod"],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
+      "sourceMaps": true,
+      "outFiles": ["${workspaceFolder}/dist/**/*.js"],
+      "env": {
+        "STUB": "true"
+      }
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Push component with suffix and separate files",
+      "program": "${workspaceFolder}/dist/index.mjs",
+      "args": ["components", "push", "--space", "295018", "--from", "295017", "--suffix", "prod", "--separate-files"],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
+      "sourceMaps": true,
+      "outFiles": ["${workspaceFolder}/dist/**/*.js"],
+      "env": {
+        "STUB": "true"
+      }
+    },
+    {
+      "type": "node",
+      "request": "launch",
       "name": "Debug Migrations generate",
       "program": "${workspaceFolder}/dist/index.mjs",
       "args": ["migrations", "generate", "--space", "295017"],

--- a/src/commands/components/push/actions.test.ts
+++ b/src/commands/components/push/actions.test.ts
@@ -239,6 +239,30 @@ describe('push components actions', () => {
       });
     });
 
+    it('should read components from consolidated files with suffix successfully', async () => {
+      vol.fromJSON({
+        '/path/to/components/12345/components.dev.json': JSON.stringify([mockComponent]),
+        '/path/to/components/12345/groups.dev.json': JSON.stringify([mockComponentGroup]),
+        '/path/to/components/12345/presets.dev.json': JSON.stringify([mockComponentPreset]),
+        '/path/to/components/12345/tags.dev.json': JSON.stringify([mockInternalTag]),
+      });
+
+      const result = await readComponentsFiles({
+        path: '/path/to/',
+        from: '12345',
+        separateFiles: false,
+        suffix: 'dev',
+        verbose: false,
+      });
+
+      expect(result).toEqual({
+        components: [mockComponent],
+        groups: [mockComponentGroup],
+        presets: [mockComponentPreset],
+        internalTags: [mockInternalTag],
+      });
+    });
+
     it('should read components from separate files successfully', async () => {
       vol.fromJSON({
         '/path/to/components/23746/component-name.json': JSON.stringify(mockComponent),
@@ -250,6 +274,54 @@ describe('push components actions', () => {
       const result = await readComponentsFiles({
         path: '/path/to/',
         from: '23746',
+        separateFiles: true,
+        verbose: false,
+      });
+
+      expect(result).toEqual({
+        components: [mockComponent],
+        groups: [mockComponentGroup],
+        presets: [mockComponentPreset],
+        internalTags: [mockInternalTag],
+      });
+    });
+
+    it('should read components from separate files with suffix successfully', async () => {
+      vol.fromJSON({
+        '/path/to/components/23747/component-name.dev.json': JSON.stringify(mockComponent),
+        '/path/to/components/23747/component-a.presets.dev.json': JSON.stringify([mockComponentPreset]),
+        '/path/to/components/23747/groups.dev.json': JSON.stringify([mockComponentGroup]),
+        '/path/to/components/23747/tags.dev.json': JSON.stringify([mockInternalTag]),
+      });
+
+      const result = await readComponentsFiles({
+        path: '/path/to/',
+        from: '23747',
+        separateFiles: true,
+        suffix: 'dev',
+        verbose: false,
+      });
+
+      expect(result).toEqual({
+        components: [mockComponent],
+        groups: [mockComponentGroup],
+        presets: [mockComponentPreset],
+        internalTags: [mockInternalTag],
+      });
+    });
+
+    it('should ignore component consolidated files if separate files are used', async () => {
+      vol.fromJSON({
+        '/path/to/components/23748/components.json': JSON.stringify([mockComponent]),
+        '/path/to/components/23748/component-name.json': JSON.stringify(mockComponent),
+        '/path/to/components/23748/component-name.presets.json': JSON.stringify([mockComponentPreset]),
+        '/path/to/components/23748/groups.json': JSON.stringify([mockComponentGroup]),
+        '/path/to/components/23748/tags.json': JSON.stringify([mockInternalTag]),
+      });
+
+      const result = await readComponentsFiles({
+        path: '/path/to/',
+        from: '23748',
         separateFiles: true,
         verbose: false,
       });

--- a/src/commands/components/push/actions.ts
+++ b/src/commands/components/push/actions.ts
@@ -358,7 +358,7 @@ async function readSeparateFiles(resolvedPath: string, suffix?: string): Promise
   };
 }
 
-async function readConsolidatedFiles(resolvedPath: string, suffix: string = ''): Promise<SpaceData> {
+async function readConsolidatedFiles(resolvedPath: string, suffix?: string): Promise<SpaceData> {
   // Read required components file
   const componentsPath = join(resolvedPath, suffix ? `components.${suffix}.json` : 'components.json');
   const componentsResult = await readJsonFile<SpaceComponent>(componentsPath);

--- a/src/commands/components/push/constants.ts
+++ b/src/commands/components/push/constants.ts
@@ -16,6 +16,10 @@ export interface PushComponentsOptions extends CommandOptions {
    * The source space id.
    */
   from?: string;
+  /**
+   * Suffix to add to the component name.
+   */
+  suffix?: string;
 }
 
 export interface ReadComponentsOptions extends PushComponentsOptions {

--- a/src/commands/components/push/index.ts
+++ b/src/commands/components/push/index.ts
@@ -23,6 +23,7 @@ componentsCommand
   .option('-f, --from <from>', 'source space id')
   .option('--fi, --filter <filter>', 'glob filter to apply to the components before pushing')
   .option('--sf, --separate-files', 'Read from separate files instead of consolidated files')
+  .option('--suffix <suffix>', 'Suffix to add to the component name')
   .action(async (componentName: string | undefined, options: PushComponentsOptions) => {
     konsola.title(` ${commands.COMPONENTS} `, colorPalette.COMPONENTS, componentName ? `Pushing component ${componentName}...` : 'Pushing components...');
     // Global options


### PR DESCRIPTION
- Introduced a new `suffix` option in the `readComponentsFiles` function to allow reading components with specific suffixes from both consolidated and separate files.
- Updated the VSCode launch configuration to include new debugging options for pushing components with and without suffixes.
- Enhanced unit tests to cover scenarios for reading components with suffixes, ensuring robust functionality and validation of the new feature.

Closes #164