### PR TITLE
Bugfix/172 generate tag restrictions

### DIFF
--- a/src/types/generate-typescript-typedefs.ts
+++ b/src/types/generate-typescript-typedefs.ts
@@ -92,6 +92,5 @@ export type GetStoryblokProvidedPropertyTypeSchemaFn = (title: string) => JSONSc
 
 export type ComponentGroupsAndNamesObject = {
   componentGroups: Map<string, Set<string>>;
-  componentTagGroups: Map<number, Set<string>>;
   componentNames: Set<string>;
 };

--- a/src/types/generate-typescript-typedefs.ts
+++ b/src/types/generate-typescript-typedefs.ts
@@ -38,6 +38,7 @@ export interface ComponentPropertySchemaOption {
 export type ComponentPropertySchema = {
   asset_link_type?: boolean;
   component_group_whitelist?: string[];
+  component_tag_whitelist?: number[];
   component_whitelist?: string[];
   email_link_type?: boolean;
   exclude_empty_option?: boolean;
@@ -46,7 +47,7 @@ export type ComponentPropertySchema = {
   options?: ComponentPropertySchemaOption[];
   pos: number;
   restrict_components?: boolean;
-  restrict_type?: "groups" | "";
+  restrict_type?: "groups" | "tags" | "";
   source?: "internal" | "external" | "internal_stories" | "internal_languages";
   type: ComponentPropertySchemaType;
   use_uuid?: boolean;
@@ -91,5 +92,6 @@ export type GetStoryblokProvidedPropertyTypeSchemaFn = (title: string) => JSONSc
 
 export type ComponentGroupsAndNamesObject = {
   componentGroups: Map<string, Set<string>>;
+  componentTagGroups: Map<number, Set<string>>;
   componentNames: Set<string>;
 };

--- a/src/utils/typescript/generateTypesFromJSONSchema.ts
+++ b/src/utils/typescript/generateTypesFromJSONSchema.ts
@@ -313,7 +313,6 @@ export class GenerateTypesFromJSONSchemas {
               const componentsInGroupWhitelist = propertyValue.component_tag_whitelist.reduce(
                 (components: string[], tagId: number) => {
                   const componentsInGroup = this.#componentGroups.get(tagId.toString());
-                  console.log("componentsInGroup", { componentsInGroup, tagId });
 
                   return componentsInGroup
                     ? [


### PR DESCRIPTION
- Generate component groups based on tags
- Generate allowed components based on components groups based on tags

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

1. Setup Component Groups based on Tags
2. Restrict Block field type components based on tags, and select existing tag
3. Pull components from space
4. Generate type defs

## What is the new behavior?

- component group is enhanced with groups formed by tags
- Blocks which are restricted by tags get correct sub component typing

## Other information
Solves https://github.com/storyblok/storyblok-cli/issues/172