### PR TITLE
feat(cli): add --no-welcome option. Log output is noisy when running multiple commands.

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,11 +23,18 @@ const program = new commander.Command();
 const allRegionsText = ALL_REGIONS.join(", ");
 
 clear();
-console.log(chalk.cyan(figlet.textSync("storyblok")));
-console.log();
-console.log();
-console.log("Hi, welcome to the Storyblok CLI");
-console.log();
+
+program
+  .option("--no-welcome", "Suppress 'welcome' message. Useful for concise output")
+  .action((options) => {
+    if (options.welcome) {
+      console.log(chalk.cyan(figlet.textSync("storyblok")));
+      console.log();
+      console.log();
+      console.log("Hi, welcome to the Storyblok CLI");
+      console.log();
+    }
+  });
 
 // non-intrusive notify users if an update available
 const notifyOptions = {


### PR DESCRIPTION
## Pull request type

Jira Link: [INT-](url)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR
- Run `pnpm dev`
The output should be as usual. "Welcome" text followed by the printed out help text.
![image](https://github.com/user-attachments/assets/04fa4c1b-503b-40c7-b293-c8b8387fdc9d)

- Run `pnpm dev --no-welcome`
Nothing's printed as expected. Neither the welcome page or the default help text.
![image](https://github.com/user-attachments/assets/d34a4701-5dc0-4192-813d-57d484ece3d1)

<!-- Please provide the steps on how to test this PR. -->

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Removes "Welcome to the Storyblok CLI" and the ASCII text from every command that is ran.

## Other information

We're using the storyblok-cli in automation, running `run-migration` in series.
`run-migration` has a very useful output but it's currently bloated by the welcome text.

![image](https://github.com/user-attachments/assets/09ab768a-5462-416a-b6cb-449ca83bce08)