### PR TITLE
fix: prevent infinite loop on push component

### DIFF
--- a/src/commands/components/push/operations.ts
+++ b/src/commands/components/push/operations.ts
@@ -264,6 +264,7 @@ export async function handleComponentGroups(
     : spaceData;
 
   // First, process groups without parents
+// This conditional handles a strange scenario where group (folders) ids are equal to their parents
   const rootGroups = groupsToProcess.filter(group => (!group.parent_uuid || group.parent_uuid === group.uuid) && !group.parent_id);
   for (const group of rootGroups) {
     const spinner = new Spinner({

--- a/src/commands/components/push/operations.ts
+++ b/src/commands/components/push/operations.ts
@@ -124,7 +124,7 @@ function findRelatedResources(
       relatedGroups.add(currentGroup);
 
       // If the group has a parent, get it from the map
-      if (currentGroup.parent_uuid && currentGroup.parent_uuid.length > 0) {
+      if (currentGroup.parent_uuid && currentGroup.parent_uuid.length > 0 && currentGroup.parent_uuid !== currentGroup.uuid) {
         currentGroup = groupsMap.get(currentGroup.parent_uuid);
       }
       else {
@@ -264,7 +264,7 @@ export async function handleComponentGroups(
     : spaceData;
 
   // First, process groups without parents
-  const rootGroups = groupsToProcess.filter(group => !group.parent_uuid && !group.parent_id);
+  const rootGroups = groupsToProcess.filter(group => (!group.parent_uuid || group.parent_uuid === group.uuid) && !group.parent_id);
   for (const group of rootGroups) {
     const spinner = new Spinner({
       verbose: !isVitest,
@@ -453,7 +453,7 @@ function getGroupHierarchy(group: SpaceComponentGroup, allGroups: SpaceComponent
   const hierarchy: SpaceComponentGroup[] = [group];
   let currentGroup = group;
 
-  while (currentGroup.parent_uuid && currentGroup.parent_uuid.length > 0) {
+  while (currentGroup.parent_uuid && currentGroup.parent_uuid.length > 0 && currentGroup.parent_uuid !== currentGroup.uuid) {
     const parentGroup = allGroups.find(g => g.uuid === currentGroup.parent_uuid);
     if (parentGroup) {
       hierarchy.unshift(parentGroup); // Add parent to the start of the array


### PR DESCRIPTION
## Pull request type

Fixes https://github.com/storyblok/storyblok-cli/issues/168

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

The corner case is not possible to reproduce in the CMS because it only affects old folders. We have to rely on unit tests. You have to trust me 😇 or we can have a call where I can show you the data on the Storyblok website space.

## What is the new behavior?

This PR extends the definition of a root group. The current definition is:
> `parent_id` is falsy and `parent_uuid` is falsy.

The new definition is:
> `parent_id` is falsy and (`parent_uuid` is falsy or `parent_uuid` is not equal to own `uuid`)

This is necessary because old root groups have `parent_id` equal to `null` but `parent_uuid` equal to their own `uuid`.