### PR TITLE
fix: implement consolidated directory for consolidated files

### DIFF
--- a/src/commands/components/pull/README.md
+++ b/src/commands/components/pull/README.md
@@ -13,10 +13,11 @@ This will download all components and their dependencies to consolidated files:
 .storyblok/
 └── components/
     └── YOUR_SPACE_ID/
-        ├── components.json      # All components
-        ├── groups.json         # Component groups
-        ├── presets.json        # Component presets
-        └── tags.json           # Component tags
+        ├── consolidated/
+        │   ├── components.json      # All components
+        │   ├── groups.json         # Component groups
+        │   ├── presets.json        # Component presets
+        │   └── tags.json           # Component tags
 ```
 
 > [!WARNING]
@@ -34,9 +35,10 @@ This will download a single component and its dependencies to:
 └── components/
     └── YOUR_SPACE_ID/
         ├── COMPONENT_NAME.json  # Single component
-        ├── groups.json         # Component groups
-        ├── COMPONENT_NAME.presets.json        # Component presets
-        └── tags.json           # Component tags
+        ├── COMPONENT_NAME.presets.json  # Component presets
+        └── consolidated/
+            ├── groups.json         # Component groups
+            └── tags.json           # Component tags
 ```
 
 ## Options
@@ -60,10 +62,11 @@ Generates:
 .storyblok/
 └── components/
     └── 12345/
-        ├── components.json      # All components
-        ├── groups.json         # Component groups
-        ├── presets.json        # Component presets
-        └── tags.json           # Component tags
+        └── consolidated/
+            ├── components.json      # All components
+            ├── groups.json         # Component groups
+            ├── presets.json        # Component presets
+            └── tags.json           # Component tags
 ```
 
 2. Pull a single component:
@@ -76,9 +79,10 @@ Generates:
 └── components/
     └── 12345/
         ├── hero.json           # Single component
-        ├── groups.json         # Component groups
         ├── hero.presets.json   # Component presets
-        └── tags.json           # Component tags
+        └── consolidated/
+            ├── groups.json         # Component groups
+            └── tags.json           # Component tags
 ```
 
 3. Pull components with a custom file name:
@@ -91,9 +95,10 @@ Generates:
 └── components/
     └── 12345/
         ├── my-components.json  # All components
-        ├── groups.json         # Component groups
-        ├── presets.json        # Component presets
-        └── tags.json           # Component tags
+        └── consolidated/
+            ├── groups.json         # Component groups
+            ├── presets.json        # Component presets
+            └── tags.json           # Component tags
 ```
 
 4. Pull components with custom suffix:
@@ -105,10 +110,11 @@ Generates:
 .storyblok/
 └── components/
     └── 12345/
-        ├── components.dev.json  # All components
-        ├── groups.json         # Component groups
-        ├── presets.json        # Component presets
-        └── tags.json           # Component tags
+        └── consolidated/
+            ├── components.dev.json  # All components
+            ├── groups.json         # Component groups
+            ├── presets.json        # Component presets
+            └── tags.json           # Component tags
 ```
 
 5. Pull components to separate files:
@@ -125,8 +131,9 @@ Generates:
         ├── feature.json
         ├── feature.presets.json
         ├── ...
-        ├── groups.json         # Component groups
-        └── tags.json           # Component tags
+        └── consolidated/
+            ├── groups.json         # Component groups
+            └── tags.json           # Component tags
 ```
 
 6. Pull components to a custom path:
@@ -138,10 +145,11 @@ Generates:
 backup/
 └── components/
     └── 12345/
-        ├── components.json      # All components
-        ├── groups.json         # Component groups
-        ├── presets.json        # Component presets
-        └── tags.json           # Component tags
+        └── consolidated/
+            ├── components.json      # All components
+            ├── groups.json         # Component groups
+            ├── presets.json        # Component presets
+            └── tags.json           # Component tags
 ```
 
 ## File Structure
@@ -151,10 +159,12 @@ The command follows this pattern for file generation:
 {path}/
 └── components/
     └── {spaceId}/
-        ├── {filename}.{suffix}.json  # Components file
-        ├── groups.json              # Component groups
-        ├── presets.json             # Component presets
-        └── tags.json                # Component tags
+        ├── consolidated/
+        │   ├── {filename}.{suffix}.json  # Components file
+        │   ├── groups.json              # Component groups
+        │   ├── presets.json             # Component presets
+        │   └── tags.json                # Component tags
+        └── {componentName}.json         # Individual components (when using --separate-files)
 ```
 
 When using `--separate-files`:
@@ -167,8 +177,9 @@ When using `--separate-files`:
         ├── {componentName2}.json
         ├── {componentName2}.presets.json
         ├── ...
-        ├── groups.json                  # Component groups
-        └── tags.json                    # Component tags
+        └── consolidated/
+            ├── groups.json              # Component groups
+            └── tags.json                # Component tags
 ```
 
 Where:

--- a/src/commands/components/pull/actions.test.ts
+++ b/src/commands/components/pull/actions.test.ts
@@ -152,7 +152,7 @@ describe('pull components actions', () => {
   describe('saveComponentsToFiles', () => {
     it('should save components to files successfully', async () => {
       vol.fromJSON({
-        '/path/to/components/12345': null,
+        '/path/to/components/12345/consolidated': null,
       });
 
       const components = [{
@@ -173,7 +173,7 @@ describe('pull components actions', () => {
         space: '12345',
       });
 
-      const files = vol.readdirSync('/path/to/components/12345');
+      const files = vol.readdirSync('/path/to/components/12345/consolidated');
       expect(files).toEqual(['components.json']);
     });
 
@@ -200,7 +200,7 @@ describe('pull components actions', () => {
         verbose: false,
       });
 
-      const files = vol.readdirSync('/path/to2/components/12345');
+      const files = vol.readdirSync('/path/to2/components/12345/consolidated');
       expect(files).toEqual(['custom.json']);
     });
 
@@ -232,7 +232,7 @@ describe('pull components actions', () => {
         console.log('TEST', error);
       }
 
-      const files = vol.readdirSync('/path/to3/components/12345');
+      const files = vol.readdirSync('/path/to3/components/12345/consolidated');
       expect(files).toEqual(['components.custom.json']);
     });
 
@@ -270,7 +270,7 @@ describe('pull components actions', () => {
       });
 
       const files = vol.readdirSync('/path/to4/components/12345');
-      expect(files).toEqual(['component-name-2.json', 'component-name.json', 'groups.json', 'tags.json']);
+      expect(files).toEqual(['component-name-2.json', 'component-name.json']);
     });
   });
 });

--- a/src/commands/components/pull/actions.ts
+++ b/src/commands/components/pull/actions.ts
@@ -109,6 +109,9 @@ export const saveComponentsToFiles = async (
     ? resolve(process.cwd(), path, 'components', space)
     : resolvePath(path, `components/${space}`);
 
+  // Create a consolidated directory for system files
+  const consolidatedPath = join(resolvedPath, 'consolidated');
+
   try {
     if (separateFiles) {
       // Save in separate files without nested structure
@@ -122,33 +125,37 @@ export const saveComponentsToFiles = async (
           const presetsFilePath = join(resolvedPath, suffix ? `${component.name}.presets.${suffix}.json` : `${component.name}.presets.json`);
           await saveToFile(presetsFilePath, JSON.stringify(componentPresets, null, 2));
         }
-        // Always save groups in a consolidated file
-        const groupsFilePath = join(resolvedPath, suffix ? `groups.${suffix}.json` : `groups.json`);
-        await saveToFile(groupsFilePath, JSON.stringify(groups, null, 2));
+      }
 
-        // Always save internal tags in a consolidated file
-        const internalTagsFilePath = join(resolvedPath, suffix ? `tags.${suffix}.json` : `tags.json`);
+      // Save consolidated files in the consolidated directory
+      if (groups.length > 0) {
+        const groupsFilePath = join(consolidatedPath, suffix ? `groups.${suffix}.json` : `groups.json`);
+        await saveToFile(groupsFilePath, JSON.stringify(groups, null, 2));
+      }
+
+      if (internalTags.length > 0) {
+        const internalTagsFilePath = join(consolidatedPath, suffix ? `tags.${suffix}.json` : `tags.json`);
         await saveToFile(internalTagsFilePath, JSON.stringify(internalTags, null, 2));
       }
       return;
     }
 
-    // Default to saving consolidated files
-    const componentsFilePath = join(resolvedPath, suffix ? `${filename}.${suffix}.json` : `${filename}.json`);
+    // Default to saving consolidated files in the consolidated directory
+    const componentsFilePath = join(consolidatedPath, suffix ? `${filename}.${suffix}.json` : `${filename}.json`);
     await saveToFile(componentsFilePath, JSON.stringify(components, null, 2));
 
     if (groups.length > 0) {
-      const groupsFilePath = join(resolvedPath, suffix ? `groups.${suffix}.json` : `groups.json`);
+      const groupsFilePath = join(consolidatedPath, suffix ? `groups.${suffix}.json` : `groups.json`);
       await saveToFile(groupsFilePath, JSON.stringify(groups, null, 2));
     }
 
     if (presets.length > 0) {
-      const presetsFilePath = join(resolvedPath, suffix ? `presets.${suffix}.json` : `presets.json`);
+      const presetsFilePath = join(consolidatedPath, suffix ? `presets.${suffix}.json` : `presets.json`);
       await saveToFile(presetsFilePath, JSON.stringify(presets, null, 2));
     }
 
     if (internalTags.length > 0) {
-      const internalTagsFilePath = join(resolvedPath, suffix ? `tags.${suffix}.json` : `tags.json`);
+      const internalTagsFilePath = join(consolidatedPath, suffix ? `tags.${suffix}.json` : `tags.json`);
       await saveToFile(internalTagsFilePath, JSON.stringify(internalTags, null, 2));
     }
   }

--- a/src/commands/components/pull/index.test.ts
+++ b/src/commands/components/pull/index.test.ts
@@ -114,7 +114,7 @@ describe('pull', () => {
         path: undefined,
         separateFiles: false,
       });
-      expect(konsola.ok).toHaveBeenCalledWith(`Components downloaded successfully to ${chalk.hex(colorPalette.PRIMARY)(`.storyblok/components/12345/components.json`)}`);
+      expect(konsola.ok).toHaveBeenCalledWith(`Components downloaded successfully to ${chalk.hex(colorPalette.PRIMARY)(`.storyblok/components/12345/consolidated/components.json`)}`);
     });
 
     it('should fetch a component by name', async () => {
@@ -144,6 +144,7 @@ describe('pull', () => {
         presets: [],
         internalTags: [],
       }, { separateFiles: true, path: undefined });
+      expect(konsola.ok).toHaveBeenCalledWith(`Component ${chalk.hex(colorPalette.PRIMARY)('component-name')} downloaded successfully in ${chalk.hex(colorPalette.PRIMARY)(`.storyblok/components/12345/component-name.json`)}`);
     });
 
     it('should throw an error if the component is not found', async () => {
@@ -206,7 +207,7 @@ describe('pull', () => {
         presets: [],
         internalTags: [],
       }, { path: '/path/to/components', separateFiles: false });
-      expect(konsola.ok).toHaveBeenCalledWith(`Components downloaded successfully to ${chalk.hex(colorPalette.PRIMARY)(`/path/to/components/components/12345/components.json`)}`);
+      expect(konsola.ok).toHaveBeenCalledWith(`Components downloaded successfully to ${chalk.hex(colorPalette.PRIMARY)(`/path/to/components/components/12345/consolidated/components.json`)}`);
     });
   });
 
@@ -240,7 +241,7 @@ describe('pull', () => {
         presets: [],
         internalTags: [],
       }, { filename: 'custom', separateFiles: false });
-      expect(konsola.ok).toHaveBeenCalledWith(`Components downloaded successfully to ${chalk.hex(colorPalette.PRIMARY)(`.storyblok/components/12345/custom.json`)}`);
+      expect(konsola.ok).toHaveBeenCalledWith(`Components downloaded successfully to ${chalk.hex(colorPalette.PRIMARY)(`.storyblok/components/12345/consolidated/custom.json`)}`);
     });
   });
 

--- a/src/commands/components/pull/index.ts
+++ b/src/commands/components/pull/index.ts
@@ -113,7 +113,7 @@ componentsCommand
       }
       else {
         const fileName = suffix ? `${filename}.${suffix}.json` : `${filename}.json`;
-        const filePath = path ? `${path}/components/${space}/${fileName}` : `.storyblok/components/${space}/${fileName}`;
+        const filePath = path ? `${path}/components/${space}/consolidated/${fileName}` : `.storyblok/components/${space}/consolidated/${fileName}`;
 
         konsola.ok(`Components downloaded successfully to ${chalk.hex(colorPalette.PRIMARY)(filePath)}`);
       }

--- a/src/commands/components/push/README.md
+++ b/src/commands/components/push/README.md
@@ -16,7 +16,11 @@ This will upload all components and their dependencies from:
 .storyblok/
 └── components/
     └── YOUR_SPACE_ID/
-        ├── components.json      # All components
+        └── consolidated/
+            ├── components.json      # All components
+            ├── groups.json         # Component groups
+            ├── presets.json        # Component presets
+            └── tags.json           # Component tags
 ```
 
 ## Push a Single Component
@@ -31,6 +35,10 @@ This will upload a single component and its dependencies from:
 └── components/
     └── YOUR_SPACE_ID/
         ├── COMPONENT_NAME.json  # Single component
+        ├── COMPONENT_NAME.presets.json  # Component presets
+        └── consolidated/
+            ├── groups.json         # Component groups
+            └── tags.json           # Component tags
 ```
 
 ## Options
@@ -55,7 +63,11 @@ Reads from:
 .storyblok/
 └── components/
     └── 12345/
-        ├── components.json      # All components
+        └── consolidated/
+            ├── components.json      # All components
+            ├── groups.json         # Component groups
+            ├── presets.json        # Component presets
+            └── tags.json           # Component tags
 ```
 
 2. Push a single component:
@@ -68,6 +80,10 @@ Reads from:
 └── components/
     └── 12345/
         ├── hero.json           # Single component
+        ├── hero.presets.json   # Component presets
+        └── consolidated/
+            ├── groups.json     # Component groups
+            └── tags.json       # Component tags
 ```
 
 3. Push components with filter:
@@ -79,7 +95,8 @@ Reads from:
 .storyblok/
 └── components/
     └── 12345/
-        ├── components.json      # All components
+        └── consolidated/
+            ├── components.json      # All components
 ```
 
 4. Push components from a different space:
@@ -91,7 +108,8 @@ Reads from:
 .storyblok/
 └── components/
     └── 67890/
-        ├── components.json      # All components
+        └── consolidated/
+            ├── components.json      # All components
 ```
 
 5. Push components from separate files:
@@ -103,11 +121,11 @@ Reads from:
 .storyblok/
 └── components/
     └── 12345/
-        ├── hero.json           # Individual components
-        ├── hero.presets.json   # Component presets
-        ├── feature.json
-        ├── feature.presets.json
-        ├── ...
+        └── consolidated/
+            ├── components.json      # All components
+            ├── groups.json         # Component groups
+            ├── presets.json        # Component presets
+            └── tags.json           # Component tags
 ```
 
 6. Push components from a custom path:
@@ -119,7 +137,11 @@ Reads from:
 backup/
 └── components/
     └── 12345/
-        ├── components.json      # All components
+        └── consolidated/
+            ├── components.json      # All components
+            ├── groups.json         # Component groups
+            ├── presets.json        # Component presets
+            └── tags.json           # Component tags
 ```
 
 ## File Structure
@@ -129,7 +151,8 @@ The command reads from the following file structure:
 {path}/
 └── components/
     └── {spaceId}/
-        ├── components.{suffix}.json  # Components file
+        └── consolidated/
+            ├── components.{suffix}.json  # Components file
 ```
 
 When using `--separate-files`:
@@ -137,11 +160,12 @@ When using `--separate-files`:
 {path}/
 └── components/
     └── {spaceId}/
-        ├── {componentName1}.{suffix}.json        # Individual components
-        ├── {componentName1}.presets.json         # Component presets
-        ├── {componentName2}.{suffix}.json
-        ├── {componentName2}.presets.json
-        ├── ...
+        └── consolidated/
+            ├── {componentName1}.{suffix}.json        # Individual components
+            ├── {componentName1}.presets.json         # Component presets
+            ├── {componentName2}.{suffix}.json
+            ├── {componentName2}.presets.json
+            ├── ...
 ```
 
 Where:

--- a/src/commands/components/push/actions.test.ts
+++ b/src/commands/components/push/actions.test.ts
@@ -387,10 +387,10 @@ describe('push components actions', () => {
   describe('readComponentsFiles', () => {
     it('should read components from consolidated files successfully', async () => {
       vol.fromJSON({
-        '/path/to/components/12345/components.json': JSON.stringify([mockComponent]),
-        '/path/to/components/12345/groups.json': JSON.stringify([mockComponentGroup]),
-        '/path/to/components/12345/presets.json': JSON.stringify([mockComponentPreset]),
-        '/path/to/components/12345/tags.json': JSON.stringify([mockInternalTag]),
+        '/path/to/components/12345/consolidated/components.json': JSON.stringify([mockComponent]),
+        '/path/to/components/12345/consolidated/groups.json': JSON.stringify([mockComponentGroup]),
+        '/path/to/components/12345/consolidated/presets.json': JSON.stringify([mockComponentPreset]),
+        '/path/to/components/12345/consolidated/tags.json': JSON.stringify([mockInternalTag]),
       });
 
       const result = await readComponentsFiles({
@@ -410,10 +410,10 @@ describe('push components actions', () => {
 
     it('should read components from consolidated files with suffix successfully', async () => {
       vol.fromJSON({
-        '/path/to/components/12345/components.dev.json': JSON.stringify([mockComponent]),
-        '/path/to/components/12345/groups.dev.json': JSON.stringify([mockComponentGroup]),
-        '/path/to/components/12345/presets.dev.json': JSON.stringify([mockComponentPreset]),
-        '/path/to/components/12345/tags.dev.json': JSON.stringify([mockInternalTag]),
+        '/path/to/components/12345/consolidated/components.dev.json': JSON.stringify([mockComponent]),
+        '/path/to/components/12345/consolidated/groups.dev.json': JSON.stringify([mockComponentGroup]),
+        '/path/to/components/12345/consolidated/presets.dev.json': JSON.stringify([mockComponentPreset]),
+        '/path/to/components/12345/consolidated/tags.dev.json': JSON.stringify([mockInternalTag]),
       });
 
       const result = await readComponentsFiles({
@@ -436,8 +436,8 @@ describe('push components actions', () => {
       vol.fromJSON({
         '/path/to/components/23746/component-name.json': JSON.stringify(mockComponent),
         '/path/to/components/23746/component-name.presets.json': JSON.stringify([mockComponentPreset]),
-        '/path/to/components/23746/groups.json': JSON.stringify([mockComponentGroup]),
-        '/path/to/components/23746/tags.json': JSON.stringify([mockInternalTag]),
+        '/path/to/components/23746/consolidated/groups.json': JSON.stringify([mockComponentGroup]),
+        '/path/to/components/23746/consolidated/tags.json': JSON.stringify([mockInternalTag]),
       });
 
       const result = await readComponentsFiles({
@@ -459,8 +459,8 @@ describe('push components actions', () => {
       vol.fromJSON({
         '/path/to/components/23747/component-name.dev.json': JSON.stringify(mockComponent),
         '/path/to/components/23747/component-a.presets.dev.json': JSON.stringify([mockComponentPreset]),
-        '/path/to/components/23747/groups.dev.json': JSON.stringify([mockComponentGroup]),
-        '/path/to/components/23747/tags.dev.json': JSON.stringify([mockInternalTag]),
+        '/path/to/components/23747/consolidated/groups.dev.json': JSON.stringify([mockComponentGroup]),
+        '/path/to/components/23747/consolidated/tags.dev.json': JSON.stringify([mockInternalTag]),
       });
 
       const result = await readComponentsFiles({
@@ -481,11 +481,11 @@ describe('push components actions', () => {
 
     it('should ignore component consolidated files if separate files are used', async () => {
       vol.fromJSON({
-        '/path/to/components/23748/components.json': JSON.stringify([mockComponent]),
+        '/path/to/components/23748/consolidated/components.json': JSON.stringify([mockComponent]),
         '/path/to/components/23748/component-name.json': JSON.stringify(mockComponent),
         '/path/to/components/23748/component-name.presets.json': JSON.stringify([mockComponentPreset]),
-        '/path/to/components/23748/groups.json': JSON.stringify([mockComponentGroup]),
-        '/path/to/components/23748/tags.json': JSON.stringify([mockInternalTag]),
+        '/path/to/components/23748/consolidated/groups.json': JSON.stringify([mockComponentGroup]),
+        '/path/to/components/23748/consolidated/tags.json': JSON.stringify([mockInternalTag]),
       });
 
       const result = await readComponentsFiles({

--- a/src/commands/components/push/actions.ts
+++ b/src/commands/components/push/actions.ts
@@ -298,6 +298,7 @@ export const readComponentsFiles = async (
     return await readSeparateFiles(resolvedPath, suffix);
   }
 
+  // When not using separate files, always look in the consolidated directory
   return await readConsolidatedFiles(resolvedPath, suffix);
 };
 
@@ -308,36 +309,50 @@ async function readSeparateFiles(resolvedPath: string, suffix?: string): Promise
   let groups: SpaceComponentGroup[] = [];
   let internalTags: SpaceComponentInternalTag[] = [];
 
+  // Read system files from consolidated directory
+  const consolidatedPath = join(resolvedPath, 'consolidated');
+  try {
+    const [groupsResult, tagsResult] = await Promise.all([
+      readJsonFile<SpaceComponentGroup>(join(consolidatedPath, suffix ? `groups.${suffix}.json` : 'groups.json')),
+      readJsonFile<SpaceComponentInternalTag>(join(consolidatedPath, suffix ? `tags.${suffix}.json` : 'tags.json')),
+    ]);
+
+    if (groupsResult.error) {
+      handleFileSystemError('read', groupsResult.error);
+    }
+    else {
+      groups = groupsResult.data;
+    }
+
+    if (tagsResult.error) {
+      handleFileSystemError('read', tagsResult.error);
+    }
+    else {
+      internalTags = tagsResult.data;
+    }
+  }
+  catch (error) {
+    // If consolidated directory doesn't exist or files are not found, continue with empty arrays
+    handleFileSystemError('read', error as Error);
+    console.warn('No consolidated directory found or system files missing. Groups and tags will be empty.');
+  }
+
+  // Filter component files
   const filteredFiles = files.filter((file) => {
     if (suffix) {
       return file.endsWith(`.${suffix}.json`);
     }
     else {
       // Regex to match files with a pattern like .<suffix>.json
-      return !/\.\w+\.json$/.test(file) || file.endsWith('.presets.json'); ;
+      return !/\.\w+\.json$/.test(file) || file.endsWith('.presets.json');
     }
   });
 
+  // Read component files from root directory
   for (const file of filteredFiles) {
     const filePath = join(resolvedPath, file);
 
-    if (file === 'groups.json' || file === `groups.${suffix}.json`) {
-      const result = await readJsonFile<SpaceComponentGroup>(filePath);
-      if (result.error) {
-        handleFileSystemError('read', result.error);
-        continue;
-      }
-      groups = result.data;
-    }
-    else if (file === 'tags.json' || file === `tags.${suffix}.json`) {
-      const result = await readJsonFile<SpaceComponentInternalTag>(filePath);
-      if (result.error) {
-        handleFileSystemError('read', result.error);
-        continue;
-      }
-      internalTags = result.data;
-    }
-    else if (file.endsWith('.presets.json') || file.endsWith(`.presets.${suffix}.json`)) {
+    if (file.endsWith('.presets.json') || file.endsWith(`.presets.${suffix}.json`)) {
       const result = await readJsonFile<SpaceComponentPreset>(filePath);
       if (result.error) {
         handleFileSystemError('read', result.error);
@@ -346,9 +361,6 @@ async function readSeparateFiles(resolvedPath: string, suffix?: string): Promise
       presets.push(...result.data);
     }
     else if (file.endsWith('.json') || file.endsWith(`${suffix}.json`)) {
-      if (file === 'components.json' || file === `components.${suffix}.json`) {
-        continue;
-      }
       const result = await readJsonFile<SpaceComponent>(filePath);
       if (result.error) {
         handleFileSystemError('read', result.error);
@@ -367,11 +379,26 @@ async function readSeparateFiles(resolvedPath: string, suffix?: string): Promise
 }
 
 async function readConsolidatedFiles(resolvedPath: string, suffix?: string): Promise<SpaceData> {
-  // Read required components file
-  const componentsPath = join(resolvedPath, suffix ? `components.${suffix}.json` : 'components.json');
+  // Read required components file from consolidated directory
+  const consolidatedPath = join(resolvedPath, 'consolidated');
+
+  // Check if consolidated directory exists
+  try {
+    await readdir(consolidatedPath);
+  }
+  catch (error) {
+    throw new FileSystemError(
+      'file_not_found',
+      'read',
+      error as Error,
+      `No consolidated directory found in ${resolvedPath}. Please make sure you have pulled the components first.`,
+    );
+  }
+
+  const componentsPath = join(consolidatedPath, suffix ? `components.${suffix}.json` : 'components.json');
   const componentsResult = await readJsonFile<SpaceComponent>(componentsPath);
 
-  if (componentsResult.error || !componentsResult.data.length) {
+  if (componentsResult.error || componentsResult.data.length === 0) {
     throw new FileSystemError(
       'file_not_found',
       'read',
@@ -380,11 +407,11 @@ async function readConsolidatedFiles(resolvedPath: string, suffix?: string): Pro
     );
   }
 
-  // Read optional files
+  // Read optional files from consolidated directory
   const [groupsResult, presetsResult, tagsResult] = await Promise.all([
-    readJsonFile<SpaceComponentGroup>(join(resolvedPath, suffix ? `groups.${suffix}.json` : 'groups.json')),
-    readJsonFile<SpaceComponentPreset>(join(resolvedPath, suffix ? `presets.${suffix}.json` : 'presets.json')),
-    readJsonFile<SpaceComponentInternalTag>(join(resolvedPath, suffix ? `tags.${suffix}.json` : 'tags.json')),
+    readJsonFile<SpaceComponentGroup>(join(consolidatedPath, suffix ? `groups.${suffix}.json` : 'groups.json')),
+    readJsonFile<SpaceComponentPreset>(join(consolidatedPath, suffix ? `presets.${suffix}.json` : 'presets.json')),
+    readJsonFile<SpaceComponentInternalTag>(join(consolidatedPath, suffix ? `tags.${suffix}.json` : 'tags.json')),
   ]);
 
   return {


### PR DESCRIPTION
- Introduced a new 'consolidated' directory structure for saving and reading component files, to avoid posible naming collision with separate files
- Updated the `saveComponentsToFiles` function to save components, groups, presets, and tags in the consolidated directory.
- Modified tests to reflect the new file paths and ensure correct functionality.
- Updated README documentation to describe the new file structure and usage.

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Jira Link: [INT-](url)

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed.

Please check the type of change your PR introduces:-->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## How to test this PR

<!-- Please provide the steps on how to test this PR. -->

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information
