### PR TITLE
fix: verbose not working command level throw

### DIFF
--- a/src/utils/error/error.ts
+++ b/src/utils/error/error.ts
@@ -4,6 +4,27 @@ import { APIError } from './api-error';
 import { CommandError } from './command-error';
 import { FileSystemError } from './filesystem-error';
 
+function handleVerboseError(error: unknown): void {
+  if (error instanceof CommandError || error instanceof APIError || error instanceof FileSystemError) {
+    const errorDetails = 'getInfo' in error ? error.getInfo() : {};
+    if (error instanceof CommandError) {
+      konsola.error(`Command Error: ${error.getInfo().message}`, errorDetails);
+    }
+    else if (error instanceof APIError) {
+      konsola.error(`API Error: ${error.getInfo().cause}`, errorDetails);
+    }
+    else if (error instanceof FileSystemError) {
+      konsola.error(`File System Error: ${error.getInfo().cause}`, errorDetails);
+    }
+    else {
+      konsola.error(`Unexpected Error: ${error}`, errorDetails);
+    }
+  }
+  else {
+    konsola.error(`Unexpected Error`, error);
+  }
+}
+
 export function handleError(error: Error | FetchError, verbose = false): void {
   // Print the message stack if it exists
   if (error instanceof APIError || error instanceof FileSystemError) {
@@ -20,20 +41,8 @@ export function handleError(error: Error | FetchError, verbose = false): void {
       header: true,
     });
   }
-  if (verbose && (error instanceof CommandError || error instanceof APIError || error instanceof FileSystemError)) {
-    const errorDetails = 'getInfo' in error ? error.getInfo() : {};
-    if (error instanceof CommandError) {
-      konsola.error(`Command Error: ${error.getInfo().message}`, errorDetails);
-    }
-    else if (error instanceof APIError) {
-      konsola.error(`API Error: ${error.getInfo().cause}`, errorDetails);
-    }
-    else if (error instanceof FileSystemError) {
-      konsola.error(`File System Error: ${error.getInfo().cause}`, errorDetails);
-    }
-    else {
-      konsola.error(`Unexpected Error: ${error}`, errorDetails);
-    }
+  if (verbose) {
+    handleVerboseError(error);
   }
   else {
     konsola.br();


### PR DESCRIPTION
This PR fixes the problem of verbose being ignored when the error is programmatically 
