### PR TITLE
feat: add signup command

### DIFF
--- a/src/commands/components/pull/index.test.ts
+++ b/src/commands/components/pull/index.test.ts
@@ -38,24 +38,7 @@ vi.mock('../../../session', () => {
   };
 });
 
-vi.mock('../../../utils', async () => {
-  const actualUtils = await vi.importActual('../../../utils');
-  return {
-    ...actualUtils,
-    isVitestRunning: true,
-    konsola: {
-      ok: vi.fn(),
-      title: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-      br: vi.fn(),
-    },
-    handleError: (error: unknown, header = false) => {
-      konsola.error(error as string, header);
-      // Optionally, prevent process.exit during tests
-    },
-  };
-});
+vi.mock('../../../utils/konsola');
 
 describe('pull', () => {
   beforeEach(() => {
@@ -157,9 +140,10 @@ describe('pull', () => {
       session().state = {
         isLoggedIn: false,
       };
-      const mockError = new CommandError(`You are currently not logged in. Please login first to get your user info.`);
       await componentsCommand.parseAsync(['node', 'test', 'pull', '--space', '12345']);
-      expect(konsola.error).toHaveBeenCalledWith(mockError, false);
+      expect(konsola.error).toHaveBeenCalledWith('You are currently not logged in. Please run storyblok login to authenticate, or storyblok signup to signup.', null, {
+        header: true,
+      });
     });
 
     it('should throw an error if the space is not provided', async () => {
@@ -172,7 +156,9 @@ describe('pull', () => {
       const mockError = new CommandError(`Please provide the space as argument --space YOUR_SPACE_ID.`);
 
       await componentsCommand.parseAsync(['node', 'test', 'pull']);
-      expect(konsola.error).toHaveBeenCalledWith(mockError, false);
+      expect(konsola.error).toHaveBeenCalledWith(mockError.message, null, {
+        header: true,
+      });
     });
   });
 

--- a/src/commands/components/pull/index.test.ts
+++ b/src/commands/components/pull/index.test.ts
@@ -141,7 +141,7 @@ describe('pull', () => {
         isLoggedIn: false,
       };
       await componentsCommand.parseAsync(['node', 'test', 'pull', '--space', '12345']);
-      expect(konsola.error).toHaveBeenCalledWith('You are currently not logged in. Please run storyblok login to authenticate, or storyblok signup to signup.', null, {
+      expect(konsola.error).toHaveBeenCalledWith('You are currently not logged in. Please run storyblok login to authenticate, or storyblok signup to sign up.', null, {
         header: true,
       });
     });

--- a/src/commands/components/pull/index.ts
+++ b/src/commands/components/pull/index.ts
@@ -2,7 +2,7 @@ import type { PullComponentsOptions } from './constants';
 
 import { Spinner } from '@topcli/spinner';
 import { colorPalette, commands } from '../../../constants';
-import { CommandError, handleError, isVitest, konsola } from '../../../utils';
+import { CommandError, handleError, isVitest, konsola, requireAuthentication } from '../../../utils';
 import { session } from '../../../session';
 import { fetchComponent, fetchComponentGroups, fetchComponentInternalTags, fetchComponentPresets, fetchComponents, saveComponentsToFiles } from '../actions';
 import { componentsCommand } from '../command';
@@ -29,8 +29,7 @@ componentsCommand
     const { state, initializeSession } = session();
     await initializeSession();
 
-    if (!state.isLoggedIn || !state.password || !state.region) {
-      handleError(new CommandError(`You are currently not logged in. Please login first to get your user info.`), verbose);
+    if (!requireAuthentication(state, verbose)) {
       return;
     }
     if (!space) {

--- a/src/commands/components/push/index.ts
+++ b/src/commands/components/push/index.ts
@@ -2,7 +2,7 @@ import type { PushComponentsOptions } from './constants';
 
 import { colorPalette, commands } from '../../../constants';
 import { getProgram } from '../../../program';
-import { CommandError, handleError, konsola } from '../../../utils';
+import { CommandError, handleError, konsola, requireAuthentication } from '../../../utils';
 import { session } from '../../../session';
 import { readComponentsFiles } from './actions';
 import { componentsCommand } from '../command';
@@ -37,8 +37,7 @@ componentsCommand
     const { state, initializeSession } = session();
     await initializeSession();
 
-    if (!state.isLoggedIn || !state.password || !state.region) {
-      handleError(new CommandError(`You are currently not logged in. Please login first to get your user info.`), verbose);
+    if (!requireAuthentication(state, verbose)) {
       return;
     }
 

--- a/src/commands/languages/index.test.ts
+++ b/src/commands/languages/index.test.ts
@@ -86,7 +86,7 @@ describe('languagesCommand', () => {
         session().state = {
           isLoggedIn: false,
         };
-        const mockError = new CommandError(`You are currently not logged in. Please run storyblok login to authenticate, or storyblok signup to signup.`);
+        const mockError = new CommandError(`You are currently not logged in. Please run storyblok login to authenticate, or storyblok signup to sign up.`);
         await languagesCommand.parseAsync(['node', 'test', 'pull', '--space', '12345']);
         expect(konsola.error).toHaveBeenCalledWith(mockError.message, null, {
           header: true,

--- a/src/commands/languages/index.test.ts
+++ b/src/commands/languages/index.test.ts
@@ -39,23 +39,7 @@ vi.mock('../../session', () => {
   };
 });
 
-vi.mock('../../utils', async () => {
-  const actualUtils = await vi.importActual('../../utils');
-  return {
-    ...actualUtils,
-    konsola: {
-      ok: vi.fn(),
-      title: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-      br: vi.fn(),
-    },
-    handleError: (error: Error, header = false) => {
-      konsola.error(error, header);
-      // Optionally, prevent process.exit during tests
-    },
-  };
-});
+vi.mock('../../utils/konsola');
 
 describe('languagesCommand', () => {
   describe('pull', () => {
@@ -102,9 +86,11 @@ describe('languagesCommand', () => {
         session().state = {
           isLoggedIn: false,
         };
-        const mockError = new CommandError(`You are currently not logged in. Please login first to get your user info.`);
+        const mockError = new CommandError(`You are currently not logged in. Please run storyblok login to authenticate, or storyblok signup to signup.`);
         await languagesCommand.parseAsync(['node', 'test', 'pull', '--space', '12345']);
-        expect(konsola.error).toHaveBeenCalledWith(mockError, false);
+        expect(konsola.error).toHaveBeenCalledWith(mockError.message, null, {
+          header: true,
+        });
       });
 
       it('should throw an error if the space is not provided', async () => {
@@ -121,7 +107,9 @@ describe('languagesCommand', () => {
         catch (error) {
           console.log('TEST languages', error);
         }
-        expect(konsola.error).toHaveBeenCalledWith(mockError, false);
+        expect(konsola.error).toHaveBeenCalledWith(mockError.message, null, {
+          header: true,
+        });
       });
 
       it('should prompt a warning the user if no languages are found', async () => {

--- a/src/commands/languages/index.ts
+++ b/src/commands/languages/index.ts
@@ -1,5 +1,5 @@
 import { colorPalette, commands } from '../../constants';
-import { CommandError, handleError, isVitest, konsola } from '../../utils';
+import { CommandError, handleError, isVitest, konsola, requireAuthentication } from '../../utils';
 import { getProgram } from '../../program';
 import { session } from '../../session';
 import { fetchLanguages, saveLanguagesToFile } from './actions';
@@ -34,8 +34,7 @@ languagesCommand
     const { state, initializeSession } = session();
     await initializeSession();
 
-    if (!state.isLoggedIn || !state.password || !state.region) {
-      handleError(new CommandError(`You are currently not logged in. Please login first to get your user info.`), verbose);
+    if (!requireAuthentication(state, verbose)) {
       return;
     }
     if (!space) {
@@ -43,13 +42,15 @@ languagesCommand
       return;
     }
 
+    const { password, region } = state;
+
     const spinner = new Spinner({
       verbose: !isVitest,
     });
     try {
       spinner.start(`Fetching ${chalk.hex(colorPalette.LANGUAGES)('languages')}`);
 
-      const internationalization = await fetchLanguages(space, state.password, state.region);
+      const internationalization = await fetchLanguages(space, password, region);
 
       if (!internationalization || internationalization.languages?.length === 0) {
         spinner.failed();

--- a/src/commands/migrations/generate/index.ts
+++ b/src/commands/migrations/generate/index.ts
@@ -4,7 +4,7 @@ import chalk from 'chalk';
 import type { MigrationsGenerateOptions } from './constants';
 import { colorPalette, commands } from '../../../constants';
 import { getProgram } from '../../../program';
-import { CommandError, handleError, isVitest, konsola } from '../../../utils';
+import { CommandError, handleError, isVitest, konsola, requireAuthentication } from '../../../utils';
 import { session } from '../../../session';
 import { fetchComponent } from '../../../commands/components';
 import { migrationsCommand } from '../command';
@@ -34,8 +34,7 @@ migrationsCommand
     const { state, initializeSession } = session();
     await initializeSession();
 
-    if (!state.isLoggedIn || !state.password || !state.region) {
-      handleError(new CommandError(`You are currently not logged in. Please login first to get your user info.`), verbose);
+    if (!requireAuthentication(state, verbose)) {
       return;
     }
     if (!space) {

--- a/src/commands/migrations/rollback/index.test.ts
+++ b/src/commands/migrations/rollback/index.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { session } from '../../../session';
-import { CommandError, konsola } from '../../../utils';
+import { konsola } from '../../../utils';
 import '../index';
 import { migrationsCommand } from '../command';
 import { readRollbackFile } from './actions';

--- a/src/commands/migrations/rollback/index.test.ts
+++ b/src/commands/migrations/rollback/index.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { session } from '../../../session';
-import { konsola } from '../../../utils';
+import { CommandError, konsola } from '../../../utils';
 import '../index';
 import { migrationsCommand } from '../command';
 import { readRollbackFile } from './actions';
@@ -8,30 +8,7 @@ import { updateStory } from '../../stories/actions';
 import type { RollbackData } from './actions';
 import type { StoryContent } from '../../stories/constants';
 
-// Mock dependencies
-vi.mock('../../../utils', async () => {
-  const actualUtils = await vi.importActual('../../../utils');
-  return {
-    ...actualUtils,
-    isVitestRunning: true,
-    konsola: {
-      ok: vi.fn(),
-      title: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-      info: vi.fn(),
-      br: vi.fn(),
-    },
-    handleError: (error: unknown) => {
-      if (error instanceof Error) {
-        konsola.error(error.message);
-      }
-      else {
-        konsola.error(String(error));
-      }
-    },
-  };
-});
+vi.mock('../../../utils/konsola');
 
 // Mock process.exit
 const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
@@ -170,9 +147,9 @@ describe('migrations rollback command', () => {
       '12345',
     ]);
 
-    expect(konsola.error).toHaveBeenCalledWith(
-      'You are currently not logged in. Please login first to get your user info.',
-    );
+    expect(konsola.error).toHaveBeenCalledWith('You are currently not logged in. Please run storyblok login to authenticate, or storyblok signup to signup.', null, {
+      header: true,
+    });
     expect(readRollbackFile).not.toHaveBeenCalled();
     expect(updateStory).not.toHaveBeenCalled();
   });
@@ -193,6 +170,10 @@ describe('migrations rollback command', () => {
 
     expect(konsola.error).toHaveBeenCalledWith(
       'Please provide the space as argument --space YOUR_SPACE_ID.',
+      null,
+      {
+        header: true,
+      },
     );
     expect(readRollbackFile).not.toHaveBeenCalled();
     expect(updateStory).not.toHaveBeenCalled();
@@ -218,6 +199,10 @@ describe('migrations rollback command', () => {
 
     expect(konsola.error).toHaveBeenCalledWith(
       'Failed to rollback migration: File not found',
+      null,
+      {
+        header: true,
+      },
     );
     expect(updateStory).not.toHaveBeenCalled();
   });

--- a/src/commands/migrations/rollback/index.test.ts
+++ b/src/commands/migrations/rollback/index.test.ts
@@ -147,7 +147,7 @@ describe('migrations rollback command', () => {
       '12345',
     ]);
 
-    expect(konsola.error).toHaveBeenCalledWith('You are currently not logged in. Please run storyblok login to authenticate, or storyblok signup to signup.', null, {
+    expect(konsola.error).toHaveBeenCalledWith('You are currently not logged in. Please run storyblok login to authenticate, or storyblok signup to sign up.', null, {
       header: true,
     });
     expect(readRollbackFile).not.toHaveBeenCalled();

--- a/src/commands/migrations/rollback/index.ts
+++ b/src/commands/migrations/rollback/index.ts
@@ -1,5 +1,5 @@
 import { colorPalette, commands } from '../../../constants';
-import { CommandError, handleError, konsola } from '../../../utils';
+import { CommandError, handleError, konsola, requireAuthentication } from '../../../utils';
 import { getProgram } from '../../../program';
 import { migrationsCommand } from '../command';
 import { session } from '../../../session';
@@ -23,8 +23,7 @@ migrationsCommand.command('rollback [migrationFile]')
     const { state, initializeSession } = session();
     await initializeSession();
 
-    if (!state.isLoggedIn || !state.password || !state.region) {
-      handleError(new CommandError(`You are currently not logged in. Please login first to get your user info.`), verbose);
+    if (!requireAuthentication(state, verbose)) {
       return;
     }
 

--- a/src/commands/migrations/run/index.ts
+++ b/src/commands/migrations/run/index.ts
@@ -1,7 +1,7 @@
 import { Spinner } from '@topcli/spinner';
 import { getProgram } from '../../../program';
 import { colorPalette, commands } from '../../../constants';
-import { CommandError, handleError, isVitest, konsola } from '../../../utils';
+import { CommandError, handleError, isVitest, konsola, requireAuthentication } from '../../../utils';
 import { session } from '../../../session';
 import type { MigrationsRunOptions } from './constants';
 import { migrationsCommand } from '../command';
@@ -35,8 +35,7 @@ migrationsCommand.command('run [componentName]')
     const { state, initializeSession } = session();
     await initializeSession();
 
-    if (!state.isLoggedIn || !state.password || !state.region) {
-      handleError(new CommandError(`You are currently not logged in. Please login first to get your user info.`), verbose);
+    if (!requireAuthentication(state, verbose)) {
       return;
     }
     if (!space) {

--- a/src/commands/signup/README.md
+++ b/src/commands/signup/README.md
@@ -1,0 +1,35 @@
+# Signup Command
+
+The signup command opens the Storyblok signup page in your browser, making it easy to create a new account.
+
+## Usage
+
+```bash
+storyblok signup
+```
+
+## How it works
+
+1. **Browser Opening**: Opens the Storyblok signup page ([https://app.storyblok.com/#/signup](https://app.storyblok.com/#/signup)) in your default browser with UTM tracking parameters
+2. **User Completes Signup**: Complete the signup process in the browser
+3. **Next Steps**: After signup, run `storyblok login` to authenticate with the CLI
+
+## Example
+
+```bash
+storyblok signup
+# Complete signup in browser
+storyblok login
+```
+
+## UTM Parameters
+
+The signup URL includes the following UTM parameters for tracking:
+- `utm_source=storyblok-cli`
+- `utm_medium=cli`
+- `utm_campaign=signup`
+
+## Error Handling
+
+- Shows a warning if the user is already logged in
+- Handles browser opening failures gracefully across different operating systems (macOS, Windows, Linux)

--- a/src/commands/signup/actions.test.ts
+++ b/src/commands/signup/actions.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { buildSignupUrl } from './actions';
+
+describe('signup actions', () => {
+  describe('buildSignupUrl', () => {
+    it('should build correct signup URL', () => {
+      const url = buildSignupUrl();
+
+      expect(url).toContain('https://app.storyblok.com/#/signup');
+      expect(url).toContain('utm_source=storyblok-cli');
+      expect(url).toContain('utm_medium=cli');
+      expect(url).toContain('utm_campaign=signup');
+    });
+
+    it('should include all UTM parameters', () => {
+      const url = buildSignupUrl();
+
+      expect(url).toContain('utm_source=storyblok-cli');
+      expect(url).toContain('utm_medium=cli');
+      expect(url).toContain('utm_campaign=signup');
+    });
+
+    it('should use the correct Storyblok app URL', () => {
+      const url = buildSignupUrl();
+      expect(url.startsWith('https://app.storyblok.com/#/signup')).toBe(true);
+    });
+  });
+});

--- a/src/commands/signup/actions.ts
+++ b/src/commands/signup/actions.ts
@@ -1,0 +1,45 @@
+import { exec } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execAsync = promisify(exec);
+
+/**
+ * Build the signup URL with UTM parameters
+ */
+export function buildSignupUrl(): string {
+  const baseUrl = 'https://app.storyblok.com';
+
+  const utmParams = new URLSearchParams({
+    utm_source: 'storyblok-cli',
+    utm_medium: 'cli',
+    utm_campaign: 'signup',
+  });
+
+  return `${baseUrl}/#/signup?${utmParams.toString()}`;
+}
+
+/**
+ * Open the signup URL in the default browser
+ */
+export async function openSignupInBrowser(url: string): Promise<void> {
+  let command: string;
+
+  switch (process.platform) {
+    case 'darwin':
+      command = `open "${url}"`;
+      break;
+    case 'win32':
+      command = `start "" "${url}"`;
+      break;
+    default:
+      command = `xdg-open "${url}"`;
+      break;
+  }
+
+  try {
+    await execAsync(command);
+  }
+  catch (error) {
+    throw new Error(`Failed to open browser: ${error}`);
+  }
+}

--- a/src/commands/signup/index.test.ts
+++ b/src/commands/signup/index.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { signupCommand } from './';
+
+// Mock dependencies
+vi.mock('./actions', () => ({
+  buildSignupUrl: vi.fn(() => 'https://app.storyblok.com/#/signup'),
+  openSignupInBrowser: vi.fn(),
+}));
+
+vi.mock('../../session', () => ({
+  session: () => ({
+    state: {
+      isLoggedIn: false,
+      envLogin: false,
+    },
+    initializeSession: vi.fn(),
+  }),
+}));
+
+vi.mock('../../utils', async () => {
+  const actualUtils = await vi.importActual('../../utils');
+  return {
+    ...actualUtils,
+    konsola: {
+      ok: vi.fn(),
+      title: vi.fn(),
+      info: vi.fn(),
+      br: vi.fn(),
+      error: vi.fn(),
+    },
+    handleError: vi.fn(),
+  };
+});
+
+describe('signupCommand', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(signupCommand).toBeDefined();
+  });
+
+  it('should have correct command name and description', () => {
+    expect(signupCommand.name()).toBe('signup');
+    expect(signupCommand.description()).toBe('Sign up for Storyblok');
+  });
+
+  it('should not have any options', () => {
+    expect(signupCommand.options).toHaveLength(0);
+  });
+});

--- a/src/commands/signup/index.ts
+++ b/src/commands/signup/index.ts
@@ -1,0 +1,47 @@
+import chalk from 'chalk';
+import { colorPalette, commands } from '../../constants';
+import { getProgram } from '../../program';
+import { handleError, konsola } from '../../utils';
+import { buildSignupUrl, openSignupInBrowser } from './actions';
+import { session } from '../../session';
+
+const program = getProgram(); // Get the shared singleton instance
+
+export const signupCommand = program
+  .command(commands.SIGNUP)
+  .description('Sign up for Storyblok')
+  .action(async () => {
+    konsola.title(` ${commands.SIGNUP} `, colorPalette.SIGNUP);
+    // Global options
+    const verbose = program.opts().verbose;
+
+    const { state, initializeSession } = session();
+
+    await initializeSession();
+
+    if (state.isLoggedIn && !state.envLogin) {
+      konsola.ok(`You are already logged in. If you want to signup with a different account, please logout first.`);
+      return;
+    }
+
+    try {
+      // Build the signup URL with UTM parameters
+      const signupUrl = buildSignupUrl();
+
+      konsola.info(`Opening Storyblok signup page...`);
+      konsola.info(`URL: ${chalk.dim(signupUrl)}`);
+
+      // Open the browser
+      await openSignupInBrowser(signupUrl);
+
+      konsola.ok(`Browser opened! Please complete the signup process.`);
+      konsola.br();
+      konsola.info(`Once you've completed signup, run ${chalk.hex(colorPalette.PRIMARY)('storyblok login')} to authenticate with the CLI.`);
+    }
+    catch (error) {
+      konsola.br();
+      handleError(error as Error, verbose);
+    }
+
+    konsola.br();
+  });

--- a/src/commands/types/generate/index.ts
+++ b/src/commands/types/generate/index.ts
@@ -1,5 +1,5 @@
 import { colorPalette, commands } from '../../../constants';
-import { CommandError, handleError, isVitest, konsola } from '../../../utils';
+import { CommandError, handleError, isVitest, konsola, requireAuthentication } from '../../../utils';
 import { getProgram } from '../../../program';
 import { session } from '../../../session';
 import { Spinner } from '@topcli/spinner';
@@ -31,8 +31,7 @@ typesCommand
     const { state, initializeSession } = session();
     await initializeSession();
 
-    if (!state.isLoggedIn || !state.password || !state.region) {
-      handleError(new CommandError(`You are currently not logged in. Please login first to get your user info.`), verbose);
+    if (!requireAuthentication(state, verbose)) {
       return;
     }
     if (!space) {

--- a/src/commands/user/index.test.ts
+++ b/src/commands/user/index.test.ts
@@ -34,22 +34,7 @@ vi.mock('../../session', () => {
   };
 });
 
-vi.mock('../../utils', async () => {
-  const actualUtils = await vi.importActual('../../utils');
-  return {
-    ...actualUtils,
-    konsola: {
-      ok: vi.fn(),
-      title: vi.fn(),
-      error: vi.fn(),
-      br: vi.fn(),
-    },
-    handleError: (error: Error, header = false) => {
-      konsola.error(error, header);
-      // Optionally, prevent process.exit during tests
-    },
-  };
-});
+vi.mock('../../utils/konsola');
 
 describe('userCommand', () => {
   beforeEach(() => {
@@ -85,7 +70,9 @@ describe('userCommand', () => {
     };
     await userCommand.parseAsync(['node', 'test']);
 
-    expect(konsola.error).toHaveBeenCalledWith(new CommandError(`You are currently not logged in. Please login first to get your user info.`), false);
+    expect(konsola.error).toHaveBeenCalledWith('You are currently not logged in. Please run storyblok login to authenticate, or storyblok signup to signup.', null, {
+      header: true,
+    });
   });
 
   it('should show an error if the user information cannot be fetched', async () => {
@@ -101,6 +88,8 @@ describe('userCommand', () => {
 
     await userCommand.parseAsync(['node', 'test']);
 
-    expect(konsola.error).toHaveBeenCalledWith(mockError, true);
+    expect(konsola.error).toHaveBeenCalledWith(mockError.message, null, {
+      header: true,
+    });
   });
 });

--- a/src/commands/user/index.test.ts
+++ b/src/commands/user/index.test.ts
@@ -70,7 +70,7 @@ describe('userCommand', () => {
     };
     await userCommand.parseAsync(['node', 'test']);
 
-    expect(konsola.error).toHaveBeenCalledWith('You are currently not logged in. Please run storyblok login to authenticate, or storyblok signup to signup.', null, {
+    expect(konsola.error).toHaveBeenCalledWith('You are currently not logged in. Please run storyblok login to authenticate, or storyblok signup to sign up.', null, {
       header: true,
     });
   });

--- a/src/commands/user/index.test.ts
+++ b/src/commands/user/index.test.ts
@@ -1,6 +1,6 @@
 import { userCommand } from './';
 import { getUser } from './actions';
-import { CommandError, konsola } from '../../utils';
+import { konsola } from '../../utils';
 import { session } from '../../session';
 import chalk from 'chalk';
 

--- a/src/commands/user/index.ts
+++ b/src/commands/user/index.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { colorPalette, commands } from '../../constants';
 import { getProgram } from '../../program';
-import { CommandError, handleError, isVitest, konsola } from '../../utils';
+import { handleError, isVitest, konsola, requireAuthentication } from '../../utils';
 import { getUser } from './actions';
 import { session } from '../../session';
 import { Spinner } from '@topcli/spinner';
@@ -16,8 +16,7 @@ export const userCommand = program
     const { state, initializeSession } = session();
     await initializeSession();
 
-    if (!state.isLoggedIn) {
-      handleError(new CommandError(`You are currently not logged in. Please login first to get your user info.`));
+    if (!requireAuthentication(state)) {
       return;
     }
     const spinner = new Spinner({

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,7 @@
 export const commands = {
   LOGIN: 'login',
   LOGOUT: 'logout',
+  SIGNUP: 'signup',
   USER: 'user',
   COMPONENTS: 'Components',
   LANGUAGES: 'languages',
@@ -12,6 +13,7 @@ export const colorPalette = {
   PRIMARY: '#8d60ff',
   LOGIN: '#dad4ff',
   LOGOUT: '#6d6d6d',
+  SIGNUP: '#b6ff6d',
   USER: '#71d300',
   COMPONENTS: '#a185ff',
   LANGUAGES: '#f5c003',

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { handleError, konsola } from './utils';
 import { getProgram } from './program';
 import './commands/login';
 import './commands/logout';
+import './commands/signup';
 import './commands/user';
 import './commands/components';
 import './commands/languages';

--- a/src/session.ts
+++ b/src/session.ts
@@ -2,7 +2,7 @@
 import { type RegionCode, regionsDomain } from './constants';
 import { addCredentials, getCredentials } from './creds';
 
-interface SessionState {
+export interface SessionState {
   isLoggedIn: boolean;
   login?: string;
   password?: string;

--- a/src/utils/__mocks__/konsola.ts
+++ b/src/utils/__mocks__/konsola.ts
@@ -1,0 +1,10 @@
+import { vi } from 'vitest';
+
+export const konsola = {
+  ok: vi.fn(),
+  title: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  br: vi.fn(),
+  info: vi.fn(),
+};

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -18,7 +18,7 @@ type AuthenticatedSessionState = SessionState & {
 export function requireAuthentication(state: SessionState, verbose = false): state is AuthenticatedSessionState {
   if (!state.isLoggedIn || !state.password || !state.region) {
     handleError(
-      new CommandError(`You are currently not logged in. Please run ${chalk.hex(colorPalette.PRIMARY)('storyblok login')} to authenticate, or ${chalk.hex(colorPalette.PRIMARY)('storyblok signup')} to signup.`),
+      new CommandError(`You are currently not logged in. Please run ${chalk.hex(colorPalette.PRIMARY)('storyblok login')} to authenticate, or ${chalk.hex(colorPalette.PRIMARY)('storyblok signup')} to sign up.`),
       verbose,
     );
     return false;

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,0 +1,25 @@
+import type { SessionState } from '../session';
+import { CommandError, handleError } from './error';
+
+type AuthenticatedSessionState = SessionState & {
+  isLoggedIn: true;
+  password: NonNullable<SessionState['password']>;
+  region: NonNullable<SessionState['region']>;
+};
+
+/**
+ * Check if user is authenticated and handle error if not
+ * @param state - Session state object
+ * @param verbose - Whether to show verbose error output
+ * @returns true if authenticated, false if not (and error is handled)
+ */
+export function requireAuthentication(state: SessionState, verbose = false): state is AuthenticatedSessionState {
+  if (!state.isLoggedIn || !state.password || !state.region) {
+    handleError(
+      new CommandError('You are currently not logged in. Please run "storyblok login" to authenticate.'),
+      verbose,
+    );
+    return false;
+  }
+  return true;
+}

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,5 +1,7 @@
+import { colorPalette } from '../constants';
 import type { SessionState } from '../session';
 import { CommandError, handleError } from './error';
+import chalk from 'chalk';
 
 type AuthenticatedSessionState = SessionState & {
   isLoggedIn: true;
@@ -16,7 +18,7 @@ type AuthenticatedSessionState = SessionState & {
 export function requireAuthentication(state: SessionState, verbose = false): state is AuthenticatedSessionState {
   if (!state.isLoggedIn || !state.password || !state.region) {
     handleError(
-      new CommandError('You are currently not logged in. Please run "storyblok login" to authenticate.'),
+      new CommandError(`You are currently not logged in. Please run ${chalk.hex(colorPalette.PRIMARY)('storyblok login')} to authenticate, or ${chalk.hex(colorPalette.PRIMARY)('storyblok signup')} to signup.`),
       verbose,
     );
     return false;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -3,6 +3,7 @@ import { dirname } from 'pathe';
 import type { RegionCode } from '../constants';
 import { regions } from '../constants';
 
+export * from './auth';
 export * from './error/';
 export * from './format';
 export * from './konsola';


### PR DESCRIPTION
Adds a new `storyblok signup` command to promote user onboarding, and refactors authentication checks for reusability.

Changes:
- Improved authentication checks, type safety and messaging
- New signup command
  - Opens the browser on signup page
  - Adds UTM tags to track command usage

![Screenshot 2025-06-09 at 10 25 59](https://github.com/user-attachments/assets/c3bd1a24-6039-41a0-92ba-4ae96f893c80)
![Screenshot 2025-06-09 at 10 26 23](https://github.com/user-attachments/assets/4e542f7d-7189-4844-9b28-bcf2e9fdcaad)